### PR TITLE
[APB-1715][MP,JR] Do not show country selection dropdown during agent subscription journey

### DIFF
--- a/app/views/edit.scala.html
+++ b/app/views/edit.scala.html
@@ -17,6 +17,7 @@
     "This page has errors", editForm
   )
 
+
   <h1 class="form-title heading-xlarge" id="pageHeading">@{journeyData.resolvedConfig.editPage.heading}</h1>
   @helpers.form(routes.AddressLookupController.handleEdit(id)) {
     <fieldset class="form-field-group">
@@ -54,15 +55,25 @@
           '_inputClass -> "form-control--block input--small"
         )
       </div>
-      <div class="form-field">
-        @helpers.dropdown(
-          editForm("countryCode"),
-          countries,
-          false,
-          '_label -> journeyData.resolvedConfig.editPage.countryLabel,
-          '_inputClass -> "form-control--block"
-        )
-      </div>
+        @if(countries.size > 1) {
+            <div class="form-field">
+            @helpers.dropdown(
+                editForm("countryCode"),
+                countries,
+                false,
+                '_label -> journeyData.resolvedConfig.editPage.countryLabel,
+                '_inputClass -> "form-control--block"
+            )
+            </div>
+        } else {
+            @alfInput(editForm("countryCode"), '_type -> "hidden")
+            <div class="form-field">
+                <label for="@countries.head._2">
+                    <span>@journeyData.resolvedConfig.editPage.countryLabel</span>
+                    <input type="text" readonly="" disabled="" class="form-control--block" value="@countries.head._2"/>
+                </label>
+            </div>
+        }
       @if(journeyData.resolvedConfig.editPage.showSearchAgainLink) {
         <div class="form-field spaced-below">
           <p><a href="@{routes.AddressLookupController.lookup(id)}">@{journeyData.resolvedConfig.editPage.searchAgainLinkText}</a></p>

--- a/app/views/edit.scala.html
+++ b/app/views/edit.scala.html
@@ -66,13 +66,17 @@
             )
             </div>
         } else {
-            @alfInput(editForm("countryCode"), '_type -> "hidden")
-            <div class="form-field">
-                <label for="@countries.head._2">
-                    <span>@journeyData.resolvedConfig.editPage.countryLabel</span>
-                    <input type="text" readonly="" disabled="" class="form-control--block" value="@countries.head._2"/>
-                </label>
-            </div>
+            @defining(countries.head._1) { countryCode =>
+                <input type="hidden" name="countryCode" value="@countryCode"/>
+            }
+            @defining(countries.head._2) { countryName =>
+                <div class="form-field">
+                    <label for="@countryName">
+                        <span>@journeyData.resolvedConfig.editPage.countryLabel</span>
+                        <input type="text" readonly="" disabled="" class="form-control--block" value="@countryName"/>
+                    </label>
+                </div>
+            }
         }
       @if(journeyData.resolvedConfig.editPage.showSearchAgainLink) {
         <div class="form-field spaced-below">

--- a/test/controllers/AddressLookupControllerSpec.scala
+++ b/test/controllers/AddressLookupControllerSpec.scala
@@ -318,17 +318,6 @@ class AddressLookupControllerSpec
       html should include element(withName("select").withAttrValue("name","countryCode"))
     }
 
-//    "show selection of countries given by allowedCountryCodes if configured" in new Scenario(
-//        journeyData = Map("foo" -> basicJourney().copy(config = basicJourney().config.copy(allowedCountryCodes = Some(Set("DE", "ZY")))))
-//    ) {
-//      val res = controller.edit("foo").apply(req)
-//      val html = contentAsString(res).asBodyFragment
-//
-//      html should not include element(withName("option").withAttrValue("value", "GB"))
-//      html should include element withName("option").withAttrValue("value", "DE")
-//      html should not include element(withName("option").withAttrValue("value", "ZY"))
-//    }
-
     "show dropdown of countries given by allowedCountryCodes if allowedCountryCodes is configured with several codes" in new Scenario(
       journeyData = Map("foo" -> basicJourney().copy(config = basicJourney().config.copy(allowedCountryCodes = Some(Set("GB", "FR")))))
     ) {
@@ -340,22 +329,21 @@ class AddressLookupControllerSpec
       html should include element withName("option").withAttrValue("value", "FR")
     }
 
-    "show single country without dropdown given by allowedCountryCodes if allowedCountryCodes is configured with a single country code" in new Scenario(
-      journeyData = Map("foo" -> basicJourney().copy(selectedAddress = Some(ConfirmableAddress("someAuditRef", None, ConfirmableAddressDetails(None, None, Some(Country("DE", "Germany"))))),
-        config = basicJourney().config.copy(allowedCountryCodes = Some(Set("DE")))))
+    "show single country without dropdown if allowedCountryCodes is configured with a single country code" in new Scenario(
+      journeyData = Map("foo" -> basicJourney().copy(config = basicJourney().config.copy(allowedCountryCodes = Some(Set("GB")))))
     ) {
       val res = controller.edit("foo").apply(req)
       val html = contentAsString(res).asBodyFragment
 
-      html should not include element(withName("option").withAttrValue("value", "DE"))
+      html should not include element(withName("option").withAttrValue("value", "GB"))
 
       html should include element withName("input")
         .withAttrValue("type", "hidden")
-        .withAttrValue("value", "DE")
+        .withAttrValue("value", "GB")
         .withAttrValue("name", "countryCode")
       html should include element withName("input")
         .withAttrValue("type", "text")
-        .withAttrValue("value", "Germany")
+        .withAttrValue("value", "United Kingdom")
         .withAttr("readonly")
         .withAttr("disabled")
     }

--- a/test/controllers/AddressLookupControllerSpec.scala
+++ b/test/controllers/AddressLookupControllerSpec.scala
@@ -67,7 +67,7 @@ class AddressLookupControllerSpec
 
     val countryService = new CountryService {
       override val GB = Country("GB", "United Kingdom")
-      override val findAll = Seq(GB, Country("DE", "Germany"))
+      override val findAll = Seq(GB, Country("DE", "Germany"), Country("FR", "France"))
       override def find(code: String) = findAll.find{ case Country(cc, _) => cc == code }
     }
 
@@ -318,30 +318,85 @@ class AddressLookupControllerSpec
       html should include element(withName("select").withAttrValue("name","countryCode"))
     }
 
-    "show selection of countries given by allowedCountryCodes if configured" in new Scenario(
-        journeyData = Map("foo" -> basicJourney().copy(config = basicJourney().config.copy(allowedCountryCodes = Some(Set("DE", "ZY")))))
+//    "show selection of countries given by allowedCountryCodes if configured" in new Scenario(
+//        journeyData = Map("foo" -> basicJourney().copy(config = basicJourney().config.copy(allowedCountryCodes = Some(Set("DE", "ZY")))))
+//    ) {
+//      val res = controller.edit("foo").apply(req)
+//      val html = contentAsString(res).asBodyFragment
+//
+//      html should not include element(withName("option").withAttrValue("value", "GB"))
+//      html should include element withName("option").withAttrValue("value", "DE")
+//      html should not include element(withName("option").withAttrValue("value", "ZY"))
+//    }
+
+    "show dropdown of countries given by allowedCountryCodes if allowedCountryCodes is configured with several codes" in new Scenario(
+      journeyData = Map("foo" -> basicJourney().copy(config = basicJourney().config.copy(allowedCountryCodes = Some(Set("GB", "FR")))))
     ) {
       val res = controller.edit("foo").apply(req)
       val html = contentAsString(res).asBodyFragment
 
-      html should not include element(withName("option").withAttrValue("value", "GB"))
-      html should include element withName("option").withAttrValue("value", "DE")
-      html should not include element(withName("option").withAttrValue("value", "ZY"))
+      html should not include element(withName("option").withAttrValue("value", "DE"))
+      html should include element withName("option").withAttrValue("value", "GB")
+      html should include element withName("option").withAttrValue("value", "FR")
     }
 
-    "editing an existing address with a country code that is not in the allowedCountryCodes config" in new Scenario(
-      journeyData = Map("foo" -> basicJourney().copy(
-        selectedAddress = Some(ConfirmableAddress("someAuditRef", None, ConfirmableAddressDetails(None, None, Some(Country("FR", "France"))))),
-        config = basicJourney().config.copy(allowedCountryCodes = Some(Set("DE"))))
-      )
+    "show single country without dropdown given by allowedCountryCodes if allowedCountryCodes is configured with a single country code" in new Scenario(
+      journeyData = Map("foo" -> basicJourney().copy(selectedAddress = Some(ConfirmableAddress("someAuditRef", None, ConfirmableAddressDetails(None, None, Some(Country("DE", "Germany"))))),
+        config = basicJourney().config.copy(allowedCountryCodes = Some(Set("DE")))))
     ) {
       val res = controller.edit("foo").apply(req)
       val html = contentAsString(res).asBodyFragment
 
-      html should not include element(withName("option").withAttrValue("value", "FR"))
-      html should not include element(withName("option").withAttrValue("value", "GB"))
-      html should include element withName("option").withAttrValue("value", "DE")
+      html should not include element(withName("option").withAttrValue("value", "DE"))
+
+      html should include element withName("input")
+        .withAttrValue("type", "hidden")
+        .withAttrValue("value", "DE")
+        .withAttrValue("name", "countryCode")
+      html should include element withName("input")
+        .withAttrValue("type", "text")
+        .withAttrValue("value", "Germany")
+        .withAttr("readonly")
+        .withAttr("disabled")
     }
+
+    "editing an existing address with a country code that is not in the allowedCountryCodes config" when {
+      "allowedCountryCodes contains multiple countries" in new Scenario(
+        journeyData = Map("foo" -> basicJourney().copy(
+          selectedAddress = Some(ConfirmableAddress("someAuditRef", None, ConfirmableAddressDetails(None, None, Some(Country("FR", "France"))))),
+          config = basicJourney().config.copy(allowedCountryCodes = Some(Set("DE", "GB"))))
+        )
+      ) {
+        val res = controller.edit("foo").apply(req)
+        val html = contentAsString(res).asBodyFragment
+
+        html should not include element(withName("option").withAttrValue("value", "FR"))
+        html should include element(withName("option").withAttrValue("value", "GB"))
+        html should include element withName("option").withAttrValue("value", "DE")
+      }
+      "allowedCountryCodes contains a single country" in new Scenario(
+        journeyData = Map("foo" -> basicJourney().copy(
+          selectedAddress = Some(ConfirmableAddress("someAuditRef", None, ConfirmableAddressDetails(None, None, Some(Country("FR", "France"))))),
+          config = basicJourney().config.copy(allowedCountryCodes = Some(Set("DE"))))
+        )
+      ) {
+        val res = controller.edit("foo").apply(req)
+        val html = contentAsString(res).asBodyFragment
+
+        html should include element withName("input")
+          .withAttrValue("type", "hidden")
+          .withAttrValue("value", "DE")
+          .withAttrValue("name", "countryCode")
+        html should include element withName("input")
+          .withAttrValue("type", "text")
+          .withAttrValue("value", "Germany")
+          .withAttr("readonly")
+          .withAttr("disabled")
+
+        html should not include element(withName("option").withAttrValue("value", "DE"))
+      }
+    }
+
     "editing an address whereby isukMode == true returns ukEditMode page" in new Scenario(
       journeyData = Map("foo" -> basicJourney(Some(true)))
     ){


### PR DESCRIPTION
Edit view altered so that dropdown is not shown when there is only one country available. Instead when only one country it is a read-only and disabled text field. Tests altered and fixed as appropriate.