### PR TITLE
TF-397 [RP] Add missing legend to radio fieldset

### DIFF
--- a/app/views/v2/select.scala.html
+++ b/app/views/v2/select.scala.html
@@ -43,7 +43,7 @@
 
     @helpers.form(controllers.routes.AddressLookupController.handleSelect(id, lookup.filter, lookup.postcode)) {
         <div class="form-group">
-            @alfInputRadioGroup(selectForm("addressId"), proposals.toHtmlOptions, '_label -> journeyData.resolveConfigV2(isWelsh).labels.selectPageLabels.proposalListLabel, '_labelClass -> "block-label")
+            @alfInputRadioGroup(selectForm("addressId"), proposals.toHtmlOptions, '_legend -> journeyData.resolveConfigV2(isWelsh).labels.selectPageLabels.proposalListLabel, '_labelClass -> "block-label")
         </div>
         <div class="form-field">
             <p><a href="@{routes.AddressLookupController.edit(id, Some(lookup.postcode), Some(true))}" id="editAddress">@{journeyData.resolveConfigV2(isWelsh).labels.selectPageLabels.editAddressLinkText}</a></p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1752124/71412067-da93b900-2643-11ea-9fe1-1f104da36f36.png)

As far as i could tell, `'_label` isn't being used in `alfInputRadioGroup`. 
I just wanted to double check that I'm not missing the use of `'_label` somewhere though. 

If i am I'll add it back.