### PR TITLE
Handle UK mode for page heading and title

### DIFF
--- a/app/model/JourneyConfigDefaults.scala
+++ b/app/model/JourneyConfigDefaults.scala
@@ -82,8 +82,8 @@ object JourneyConfigDefaults {
     val EDIT_PAGE_COUNTRY_LABEL = "Country"
     val EDIT_PAGE_SUBMIT_LABEL = "Continue"
 
-    val LOOKUP_PAGE_TITLE = "Find the address"
-    val LOOKUP_PAGE_HEADING = "Find the address"
+    val LOOKUP_PAGE_TITLE = "Find $UK address"
+    val LOOKUP_PAGE_HEADING = "Find $UK address"
     val LOOKUP_PAGE_FILTER_LABEL = "Property name or number (optional)"
     val LOOKUP_PAGE_POSTCODE_LABEL = "UK postcode"
     val LOOKUP_PAGE_SUBMIT_LABEL = "Find address"
@@ -121,8 +121,8 @@ object JourneyConfigDefaults {
     val EDIT_PAGE_COUNTRY_LABEL = "Gwlad"
     val EDIT_PAGE_SUBMIT_LABEL = "Yn eich blaen"
 
-    val LOOKUP_PAGE_TITLE = "Dod o hyd i’r cyfeiriad"
-    val LOOKUP_PAGE_HEADING = "Dod o hyd i’r cyfeiriad"
+    val LOOKUP_PAGE_TITLE = "Dod o hyd i’r $UK cyfeiriad"
+    val LOOKUP_PAGE_HEADING = "Dod o hyd i’r $UK cyfeiriad"
     val LOOKUP_PAGE_FILTER_LABEL = "Enw neu rif yr eiddo"
     val LOOKUP_PAGE_POSTCODE_LABEL = "Cod post yn y DU"
     val LOOKUP_PAGE_SUBMIT_LABEL = "Chwiliwch am y cyfeiriad"

--- a/app/model/Model.scala
+++ b/app/model/Model.scala
@@ -32,7 +32,7 @@ case class Edit(line1: String, line2: Option[String], line3: Option[String], tow
 // but which have fallbacks so that client apps do not need to specify a value except to override the default are decorated
 case class ResolvedJourneyConfig(cfg: JourneyConfig) {
   val continueUrl: String = cfg.continueUrl
-  val lookupPage: ResolvedLookupPage = ResolvedLookupPage(cfg.lookupPage.getOrElse(LookupPage()), cfg.isukMode)
+  val lookupPage: ResolvedLookupPage = ResolvedLookupPage(cfg.lookupPage.getOrElse(LookupPage()), cfg.ukMode.get)
   val selectPage: ResolvedSelectPage = ResolvedSelectPage(cfg.selectPage.getOrElse(SelectPage()))
   val confirmPage: ResolvedConfirmPage = ResolvedConfirmPage(cfg.confirmPage.getOrElse(ConfirmPage()))
   val editPage: ResolvedEditPage = ResolvedEditPage(cfg.editPage.getOrElse(EditPage()))
@@ -79,9 +79,9 @@ case class ConfirmPage(title: Option[String] = None,
                        confirmChangeText: Option[String] = None
                       )
 
-case class ResolvedLookupPage(p: LookupPage, isukMode: Boolean) {
-  val title: String = p.title.getOrElse(LOOKUP_PAGE_TITLE)
-  val heading: String = p.heading.getOrElse(LOOKUP_PAGE_HEADING)
+case class ResolvedLookupPage(p: LookupPage, isUkMode: Boolean) {
+  val title: String = p.title.getOrElse(LOOKUP_PAGE_TITLE).replaceAll("\\$UK", if (isUkMode) "UK" else "")
+  val heading: String = p.heading.getOrElse(LOOKUP_PAGE_HEADING).replaceAll("\\$UK", if (isUkMode) "UK" else "")
   val filterLabel: String = p.filterLabel.getOrElse(LOOKUP_PAGE_FILTER_LABEL)
   val postcodeLabel: String = p.postcodeLabel.getOrElse(LOOKUP_PAGE_POSTCODE_LABEL)
   val submitLabel: String = p.submitLabel.getOrElse(LOOKUP_PAGE_SUBMIT_LABEL)

--- a/app/model/ResolvedModelV2.scala
+++ b/app/model/ResolvedModelV2.scala
@@ -9,11 +9,11 @@ case class ResolvedJourneyConfigV2(journeyConfig: JourneyConfigV2, isWelsh: Bool
 
   val labels: ResolvedLanguageLabels = journeyConfig.labels match {
     case Some(JourneyLabels(_, Some(welshLanguageLabels))) if isWelsh =>
-      ResolvedLanguageLabels(welshLanguageLabels, options.phaseFeedbackLink, WelshConstants)
+      ResolvedLanguageLabels(welshLanguageLabels, options.phaseFeedbackLink, WelshConstants, options.isUkMode)
     case Some(JourneyLabels(Some(englishLanguageLabels), _)) =>
-      ResolvedLanguageLabels(englishLanguageLabels, options.phaseFeedbackLink, EnglishConstants)
+      ResolvedLanguageLabels(englishLanguageLabels, options.phaseFeedbackLink, EnglishConstants, options.isUkMode)
     case _ =>
-      ResolvedLanguageLabels(LanguageLabels(), options.phaseFeedbackLink, EnglishConstants)
+      ResolvedLanguageLabels(LanguageLabels(), options.phaseFeedbackLink, EnglishConstants, options.isUkMode)
   }
 }
 
@@ -49,10 +49,10 @@ case class ResolvedConfirmPageConfig(confirmPageConfig: ConfirmPageConfig) {
   val showConfirmChangeText: Boolean = confirmPageConfig.showConfirmChangeText.getOrElse(false)
 }
 
-case class ResolvedLanguageLabels(languageLabels: LanguageLabels, phaseFeedbackLink: String, journeyConfigDefaults: JourneyConfigDefaults) {
+case class ResolvedLanguageLabels(languageLabels: LanguageLabels, phaseFeedbackLink: String, journeyConfigDefaults: JourneyConfigDefaults, isUkMode: Boolean) {
   val appLevelLabels: ResolvedAppLevelLabels = ResolvedAppLevelLabels(languageLabels.appLevelLabels.getOrElse(AppLevelLabels()), phaseFeedbackLink)
   val selectPageLabels: ResolvedSelectPageLabels = ResolvedSelectPageLabels(languageLabels.selectPageLabels.getOrElse(SelectPageLabels()))
-  val lookupPageLabels: ResolvedLookupPageLabels = ResolvedLookupPageLabels(languageLabels.lookupPageLabels.getOrElse(LookupPageLabels()))
+  val lookupPageLabels: ResolvedLookupPageLabels = ResolvedLookupPageLabels(languageLabels.lookupPageLabels.getOrElse(LookupPageLabels()), isUkMode)
   val editPageLabels: ResolvedEditPageLabels = ResolvedEditPageLabels(languageLabels.editPageLabels.getOrElse(EditPageLabels()))
   val confirmPageLabels: ResolvedConfirmPageLabels = ResolvedConfirmPageLabels(languageLabels.confirmPageLabels.getOrElse(ConfirmPageLabels()))
 
@@ -71,9 +71,9 @@ case class ResolvedLanguageLabels(languageLabels: LanguageLabels, phaseFeedbackL
     val editAddressLinkText: String = selectPageLabels.editAddressLinkText.getOrElse(journeyConfigDefaults.EDIT_LINK_TEXT)
   }
 
-  case class ResolvedLookupPageLabels(lookupPageLabels: LookupPageLabels) {
-    val title: String = lookupPageLabels.title.getOrElse(journeyConfigDefaults.LOOKUP_PAGE_TITLE)
-    val heading: String = lookupPageLabels.heading.getOrElse(journeyConfigDefaults.LOOKUP_PAGE_HEADING)
+  case class ResolvedLookupPageLabels(lookupPageLabels: LookupPageLabels, isUkMode: Boolean) {
+    val title: String = lookupPageLabels.title.getOrElse(journeyConfigDefaults.LOOKUP_PAGE_TITLE).replaceAll("\\$UK", if (isUkMode) "UK" else "")
+    val heading: String = lookupPageLabels.heading.getOrElse(journeyConfigDefaults.LOOKUP_PAGE_HEADING).replaceAll("\\$UK", if (isUkMode) "UK" else "")
     val filterLabel: String = lookupPageLabels.filterLabel.getOrElse(journeyConfigDefaults.LOOKUP_PAGE_FILTER_LABEL)
     val postcodeLabel: String = lookupPageLabels.postcodeLabel.getOrElse(journeyConfigDefaults.LOOKUP_PAGE_POSTCODE_LABEL)
     val submitLabel: String = lookupPageLabels.submitLabel.getOrElse(journeyConfigDefaults.LOOKUP_PAGE_SUBMIT_LABEL)


### PR DESCRIPTION
This is a WIP proposal for how we can handle conditional UK mode in user provided config labels.

The idea is that any reference to `$UK` in the label will be replaced by `UK` when ukMode is true, otherwise it'll be removed.

I'm sure there's probably a better way to handle this though so please let me know your thoughts