### PR TITLE
TF-410 Only show language toggle for v2

### DIFF
--- a/app/model/ModelV2.scala
+++ b/app/model/ModelV2.scala
@@ -12,8 +12,7 @@ case class JourneyDataV2(config: JourneyConfigV2,
 
   def resolveConfigV2(isWelsh: Boolean = false) = ResolvedJourneyConfigV2(config, isWelsh)
 
-  val welshEnabled: Boolean = true
-
+  val welshEnabled: Boolean = (config.version != 1) || (config.labels exists (_.cy.isDefined))
 }
 
 case class JourneyConfigV2(version: Int,


### PR DESCRIPTION
This _should_ make the language toggle configurable for v1 users of the service, however from investigation it seems that `"version": 2` is being added to the config for v1 users.