### PR TITLE
TF-535 language toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Journey configuration is supplied as a JSON object in the body of the request to
 
 It is **not** necessary to specify values for all configurable properties. _Only supply a value for properties where it is either required or you need to override the default_. Wherever possible, sensible defaults have been provided. The default values are indicated in the table detailing the options below.
 
-A "cy" object is required within the labels section to enable the Welsh journey, even if no custom content is provided. This is to allow calling services to specify whether Welsh should be available. Welsh content is displayed for users when the "cy" object has been included and the PLAY_LANG cookie is set to "cy". A link to enable users to change their language will be displayed when the Welsh journey is enabled.
+A "cy" object is required if you wish to provide custom labels for the Welsh journey. If no custom content is provided, the default labels are used. Welsh content is displayed for users when the PLAY_LANG cookie is set to "cy". A link to enable users to change their language will be displayed on all pages.
 
 ```json
 {

--- a/app/model/ModelV2.scala
+++ b/app/model/ModelV2.scala
@@ -12,12 +12,13 @@ case class JourneyDataV2(config: JourneyConfigV2,
 
   def resolveConfigV2(isWelsh: Boolean = false) = ResolvedJourneyConfigV2(config, isWelsh)
 
-  val welshEnabled: Boolean = (config.version != 1) || (config.labels exists (_.cy.isDefined))
+  val welshEnabled: Boolean = !config.requestedVersion.contains(1)
 }
 
 case class JourneyConfigV2(version: Int,
                            options: JourneyOptions,
-                           labels: Option[JourneyLabels] = None
+                           labels: Option[JourneyLabels] = None,
+                           requestedVersion: Option[Int] = None
                           )
 
 case class JourneyOptions(continueUrl: String,

--- a/app/model/ModelV2.scala
+++ b/app/model/ModelV2.scala
@@ -12,8 +12,7 @@ case class JourneyDataV2(config: JourneyConfigV2,
 
   def resolveConfigV2(isWelsh: Boolean = false) = ResolvedJourneyConfigV2(config, isWelsh)
 
-  val welshEnabled: Boolean = true
-
+  val welshEnabled: Boolean = (config.version != 1) || (config.labels exists (_.cy.isDefined))
 }
 
 case class JourneyConfigV2(version: Int,

--- a/app/utils/V2ModelConverter.scala
+++ b/app/utils/V2ModelConverter.scala
@@ -13,7 +13,8 @@ object V2ModelConverter {
       version = FrontendAppConfig.apiVersion2,
       options = resolveJourneyOptions(v1.config),
       labels = resolveLabels(v1.config.navTitle, v1.config.phaseBannerHtml, v1.config.lookupPage, v1.config.selectPage,
-        v1.config.editPage, v1.config.confirmPage)
+        v1.config.editPage, v1.config.confirmPage),
+      requestedVersion = Some(1)
     )
 
     JourneyDataV2(journeyConfig, v1.proposals, v1.selectedAddress, v1.confirmedAddress)

--- a/test/services/KeystoreJourneyRepositorySpec.scala
+++ b/test/services/KeystoreJourneyRepositorySpec.scala
@@ -266,7 +266,7 @@ class KeystoreJourneyRepositorySpec extends PlaySpec with OneAppPerSuite with Sc
     "all options set" should {
       "Create a valid v2 model" in new Scenario() {
         val actual = convertToV2Model(fullV1JourneyData)
-        val expected = fullV2JourneyData
+        val expected = fullV2JourneyDataFromV1
 
         actual mustEqual expected
       }
@@ -275,7 +275,7 @@ class KeystoreJourneyRepositorySpec extends PlaySpec with OneAppPerSuite with Sc
     "without a selected address" should {
       "return a V2 model without a selected address" in new Scenario() {
         val actual = convertToV2Model(fullV1JourneyData.copy(selectedAddress = None))
-        val expected = fullV2JourneyData.copy(selectedAddress = None)
+        val expected = fullV2JourneyDataFromV1.copy(selectedAddress = None)
 
         actual mustEqual expected
       }
@@ -284,7 +284,7 @@ class KeystoreJourneyRepositorySpec extends PlaySpec with OneAppPerSuite with Sc
     "without a confirmed address" should {
       "return a V2 model without a confirmed address" in new Scenario() {
         val actual = convertToV2Model(fullV1JourneyData.copy(confirmedAddress = None))
-        val expected = fullV2JourneyData.copy(confirmedAddress = None)
+        val expected = fullV2JourneyDataFromV1.copy(confirmedAddress = None)
 
         actual mustEqual expected
       }
@@ -293,7 +293,7 @@ class KeystoreJourneyRepositorySpec extends PlaySpec with OneAppPerSuite with Sc
     "without a list of proposed addresses" should {
       "return a V2 model without a list of proposed addresses" in new Scenario() {
         val actual = convertToV2Model(fullV1JourneyData.copy(proposals = None))
-        val expected = fullV2JourneyData.copy(proposals = None)
+        val expected = fullV2JourneyDataFromV1.copy(proposals = None)
 
         actual mustEqual expected
       }
@@ -305,7 +305,7 @@ class KeystoreJourneyRepositorySpec extends PlaySpec with OneAppPerSuite with Sc
         val v1JourneyData = fullV1JourneyData.copy(config = v1Config)
         val v2Config = fullV2JourneyConfig.copy(labels = Some(JourneyLabels(
           en = Some(fullV2LanguageLabelsEn.copy(lookupPageLabels = None))
-        )))
+        )), requestedVersion = Some(1))
 
         val actual = convertToV2Model(v1JourneyData)
         val expected = fullV2JourneyData.copy(config = v2Config)
@@ -322,7 +322,7 @@ class KeystoreJourneyRepositorySpec extends PlaySpec with OneAppPerSuite with Sc
           options = fullV2JourneyOptions.copy(selectPageConfig = None),
           labels = Some(JourneyLabels(
             en = Some(fullV2LanguageLabelsEn.copy(selectPageLabels = None))
-          )))
+          )), requestedVersion = Some(1))
 
         val actual = convertToV2Model(v1JourneyData)
         val expected = fullV2JourneyData.copy(config = v2Config)
@@ -338,7 +338,7 @@ class KeystoreJourneyRepositorySpec extends PlaySpec with OneAppPerSuite with Sc
         val v2Config = fullV2JourneyConfig.copy(
           labels = Some(JourneyLabels(
             en = Some(fullV2LanguageLabelsEn.copy(editPageLabels = None))
-          )))
+          )), requestedVersion = Some(1))
 
         val actual = convertToV2Model(v1JourneyData)
         val expected = fullV2JourneyData.copy(config = v2Config)
@@ -355,7 +355,7 @@ class KeystoreJourneyRepositorySpec extends PlaySpec with OneAppPerSuite with Sc
           options = fullV2JourneyOptions.copy(confirmPageConfig = None),
           labels = Some(JourneyLabels(
             en = Some(fullV2LanguageLabelsEn.copy(confirmPageLabels = None))
-          )))
+          )), requestedVersion = Some(1))
 
         val actual = convertToV2Model(v1JourneyData)
         val expected = fullV2JourneyData.copy(config = v2Config)
@@ -390,7 +390,8 @@ class KeystoreJourneyRepositorySpec extends PlaySpec with OneAppPerSuite with Sc
           ),
           labels = Some(JourneyLabels(
             en = Some(fullV2LanguageLabelsEn.copy(appLevelLabels = None))
-          )))
+          )),
+          requestedVersion = Some(1))
 
         val actual = convertToV2Model(v1JourneyData)
         val expected = fullV2JourneyData.copy(config = v2Config)
@@ -421,7 +422,8 @@ class KeystoreJourneyRepositorySpec extends PlaySpec with OneAppPerSuite with Sc
               editPageLabels = None,
               confirmPageLabels = None
             ))
-          )))
+          )),
+          requestedVersion = Some(1))
 
         val actual = convertToV2Model(v1JourneyData)
         val expected = fullV2JourneyData.copy(config = v2Config)

--- a/test/utils/TestConstants.scala
+++ b/test/utils/TestConstants.scala
@@ -190,6 +190,8 @@ object TestConstants {
 
   val fullV2JourneyData = JourneyDataV2(fullV2JourneyConfig, Some(testProposedAddressSeq), Some(testAddress), Some(testAddress))
 
+  val fullV2JourneyDataFromV1 = JourneyDataV2(fullV2JourneyConfig.copy(requestedVersion = Some(1)), Some(testProposedAddressSeq), Some(testAddress), Some(testAddress))
+
   val emptyJson: JsValue = Json.parse("{}")
 
   val confirmPageLabelsMinimal = ConfirmPageLabels(None, None, None, None, None, None, None, None)


### PR DESCRIPTION
Disables the language toggle for V1 users because they haven't been translated into Welsh.

This is done by internally flagging requests for the V1 config so that we can tell which version a service is using. 

Prior to this PR, V1 config was being was being converted to V2 which was forcibly setting the version option to 2.