### PR TITLE
TF-535 Ignore cy block for toggling language

### DIFF
--- a/app/controllers/AddressLookupController.scala
+++ b/app/controllers/AddressLookupController.scala
@@ -46,7 +46,7 @@ class AddressLookupController @Inject()(journeyRepository: JourneyRepository, ad
   }
 
   def getWelshContent(journeyData: JourneyDataV2)(implicit request: Request[_]): Boolean = {
-    journeyData.config.labels.flatMap(_.cy).isDefined && request.cookies.exists(kv => kv.name == "PLAY_LANG" && kv.value == "cy")
+    request.cookies.exists(kv => kv.name == "PLAY_LANG" && kv.value == "cy")
   }
 
   def requestWithWelshHeader(useWelsh: Boolean)(req: => Result) = {

--- a/app/model/ResolvedModelV2.scala
+++ b/app/model/ResolvedModelV2.scala
@@ -13,7 +13,11 @@ case class ResolvedJourneyConfigV2(journeyConfig: JourneyConfigV2, isWelsh: Bool
     case Some(JourneyLabels(Some(englishLanguageLabels), _)) =>
       ResolvedLanguageLabels(englishLanguageLabels, options.phaseFeedbackLink, EnglishConstants(options.isUkMode))
     case _ =>
-      ResolvedLanguageLabels(LanguageLabels(), options.phaseFeedbackLink, EnglishConstants(options.isUkMode))
+      if (isWelsh) {
+        ResolvedLanguageLabels(LanguageLabels(), options.phaseFeedbackLink, WelshConstants(options.isUkMode))
+      } else {
+        ResolvedLanguageLabels(LanguageLabels(), options.phaseFeedbackLink, EnglishConstants(options.isUkMode))
+      }
   }
 }
 

--- a/test/controllers/AddressLookupControllerSpec.scala
+++ b/test/controllers/AddressLookupControllerSpec.scala
@@ -1002,14 +1002,14 @@ class AddressLookupControllerSpec
       "there is a welsh language cookie in the request and welsh is setup in the journey with labels" in new Scenario {
         controller.getWelshContent(testLookupLevelCYJourneyConfigV2)(reqWelsh) mustBe true
       }
+      "there is a welsh language cookie in the request and welsh is not setup in the journey" in new Scenario {
+        controller.getWelshContent(testLookupLevelJourneyConfigV2)(reqWelsh) mustBe true
+      }
     }
     "return false" when {
       "there is no welsh language cookie but welsh labels are provided" in new Scenario {
         val reqOther = FakeRequest().withCookies(Cookie(Play.langCookieName, "en"))
         controller.getWelshContent(testLookupLevelCYJourneyConfigV2)(reqOther) mustBe false
-      }
-      "there is a welsh language cookie in the request and welsh is not setup in the journey" in new Scenario {
-        controller.getWelshContent(testLookupLevelJourneyConfigV2)(reqWelsh) mustBe false
       }
     }
   }

--- a/test/controllers/AddressLookupControllerSpec.scala
+++ b/test/controllers/AddressLookupControllerSpec.scala
@@ -288,21 +288,21 @@ class AddressLookupControllerSpec
           html.getElementById("filter").`val` mustBe "The House"
         }
       }
-      "Welsh default content is not available" should {
-        "return English default content" in new Scenario(
+      "Welsh default content is not provided" should {
+        "return default Welsh content" in new Scenario(
           journeyDataV2 = Map("foo" -> basicJourneyV2(ukModeBool = Some(true)))
         ) {
           val res = call(controller.lookup("foo"), reqWelsh)
           val html = contentAsString(res).asBodyFragment
-          html should include element withName("title").withValue("Find UK address")
-          html should include element withName("h1").withValue("Find UK address")
+          html should include element withName("title").withValue("Dod o hyd i gyfeiriad yn y DU")
+          html should include element withName("h1").withValue("Dod o hyd i gyfeiriad yn y DU")
           html should include element withName("form").withAttrValue("action", routes.AddressLookupController.select("foo").url)
-          html should include element withName("label").withAttrValue("for", "filter").withValue("Property name or number (optional)")
+          html should include element withName("label").withAttrValue("for", "filter").withValue("Enw neu rif yr eiddo (dewisol)")
           html should include element withName("input").withAttrValue("name", "filter")
-          html should include element withName("label").withAttrValue("for", "postcode").withValue("UK postcode")
+          html should include element withName("label").withAttrValue("for", "postcode").withValue("Cod post yn y DU")
           html should include element withName("input").withAttrValue("name", "postcode")
-          html should include element withName("button").withAttrValue("type", "submit").withValue("Find address")
-          html should include element withAttrValue("id", "manualAddress").withValue("The address does not have a UK Postcode")
+          html should include element withName("button").withAttrValue("type", "submit").withValue("Chwiliwch am y cyfeiriad")
+          html should include element withAttrValue("id", "manualAddress").withValue("Nid oes gan y cyfeiriad god post yn y DU")
           html.getElementById("postcode").`val` mustBe ""
           html.getElementById("filter").`val` mustBe ""
         }


### PR DESCRIPTION
Welsh defaults are provided for all content throughout the service now and as a result of the DAC audit the language toggle should always be present on all screens.

Prior to this change, a `cy: {}` block had to exist in the config, but as we've decided to remove that requirement, the check for that block has been removed. However, when toggling the language it appears that the customisable messages via config aren't being translated.

![image](https://user-images.githubusercontent.com/1752124/75767793-a7585f00-5d43-11ea-9959-1e0a76a945df.png)

[I've isolated this to the following lines of code](https://github.com/hmrc/address-lookup-frontend/blob/edee24ddc0a390b310e4e39f58acae633abc3b0c/app/model/ResolvedModelV2.scala#L10-L17), but I can't figure out why the welsh labels aren't being returned. Pretty sure it's down to my lack of understanding of scala more than anything else.