### PR TITLE
Result sorting

### DIFF
--- a/app/controllers/AddressLookupController.scala
+++ b/app/controllers/AddressLookupController.scala
@@ -362,9 +362,9 @@ case class Proposals(proposals: Option[Seq[ProposedAddress]]) {
 
   def toHtmlOptions: Seq[(String, String)] = {
     proposals.map { props =>
-      props.map { addr =>
-        (addr.addressId, addr.toDescription)
-      }
+      props.map { addr => {
+        (addr.addressId, addr.toDescription)}
+      }.sorted
     }.getOrElse(Seq.empty)
   }
 }

--- a/test/controllers/ProposalsSpec.scala
+++ b/test/controllers/ProposalsSpec.scala
@@ -1,0 +1,23 @@
+package controllers
+
+import model.ProposedAddress
+import uk.gov.hmrc.play.test.UnitSpec
+
+class ProposalsSpec extends UnitSpec {
+
+  "proposals" should {
+    "naturally sort proposed addresses by addressId" in {
+      val unsortedProposals = Seq(ProposedAddress(addressId = "GB990091234525", lines = List("1 main road"), postcode = "ZZ11 1ZZ"),
+                                  ProposedAddress(addressId = "GB990091234530", lines = List("10 main road"), postcode = "ZZ11 1ZZ"),
+                                  ProposedAddress(addressId = "GB990091234526", lines = List("2 main road"), postcode = "ZZ11 1ZZ"))
+
+      val proposals = Proposals(Some(unsortedProposals)).toHtmlOptions
+
+      val expectedProposals = Seq(("GB990091234525", "1 main road, ZZ11 1ZZ"),
+                                  ("GB990091234526", "2 main road, ZZ11 1ZZ"),
+                                  ("GB990091234530", "10 main road, ZZ11 1ZZ"))
+
+      proposals shouldBe expectedProposals
+    }
+  }
+}


### PR DESCRIPTION
Raised by @adamliptrot-oc ...

## Check ordering of addresses

using TF1 3PY as the postcode provided addresses out of numeric sequence.

![image](https://user-images.githubusercontent.com/1752124/79566086-3b8f4300-80b2-11ea-8b96-969f879253da.png)
