### PR TITLE
TF-633: Fix issue with UK mode = true when entering address manually from "Too many addresses" or "No results found" page

### DIFF
--- a/app/model/JourneyConfigDefaults.scala
+++ b/app/model/JourneyConfigDefaults.scala
@@ -78,7 +78,7 @@ object JourneyConfigDefaults {
     val EDIT_PAGE_LINE2_LABEL = "Address line 2 (optional)"
     val EDIT_PAGE_LINE3_LABEL = "Address line 3 (optional)"
     val EDIT_PAGE_TOWN_LABEL = "Town/city"
-    val EDIT_PAGE_POSTCODE_LABEL = "Postcode (optional)"
+    val EDIT_PAGE_POSTCODE_LABEL = if(isUkMode) "UK postcode (optional)" else "Postcode (optional)"
     val EDIT_PAGE_COUNTRY_LABEL = "Country"
     val EDIT_PAGE_SUBMIT_LABEL = "Continue"
 
@@ -117,7 +117,7 @@ object JourneyConfigDefaults {
     val EDIT_PAGE_LINE2_LABEL = "Llinell cyfeiriad 2 (dewisol)"
     val EDIT_PAGE_LINE3_LABEL = "Llinell cyfeiriad 3 (dewisol)"
     val EDIT_PAGE_TOWN_LABEL = "Tref/dinas"
-    val EDIT_PAGE_POSTCODE_LABEL = "Cod post (dewisol)"
+    val EDIT_PAGE_POSTCODE_LABEL = if(isUkMode) "Cod post y DU (dewisol)" else "Cod post (dewisol)"
     val EDIT_PAGE_COUNTRY_LABEL = "Gwlad"
     val EDIT_PAGE_SUBMIT_LABEL = "Yn eich blaen"
 

--- a/app/views/no_results.scala.html
+++ b/app/views/no_results.scala.html
@@ -21,5 +21,5 @@
 </div>
 }
 
-<a href="@{routes.AddressLookupController.edit(id,None,Some(true))}" id="enterManual">@messages("results.manual.entry.text")</a>
+<a href="@{routes.AddressLookupController.edit(id,None,journeyData.resolvedConfig.cfg.ukMode)}" id="enterManual">@messages("results.manual.entry.text")</a>
 }

--- a/app/views/too_many_results.scala.html
+++ b/app/views/too_many_results.scala.html
@@ -24,15 +24,15 @@
 <p>@messages("too.many.you.entered.text")</p>
 <ul class="list list-bullet">
     <li>@{lookup.postcode} @messages("common.for.postcode.text")</li>
-    <li>@{lookup.filter.fold(messages("too.many.nothing.text"))(filter => s"'${filter}' ${messages("too.many.name.number.text")}")}</li>
+    <li>@{lookup.filter.fold(messages("too.many.nothing.text"))(filter => s"'$filter' ${messages("too.many.name.number.text")}")}</li>
 
 </ul>
-</br>
+<br />
 
 <div class="form-group">
     <a href="@{routes.AddressLookupController.lookup(id,Some(lookup.postcode),lookup.filter)}"><button class="button" type="submit" id="continue">@messages("too.many.another.search.text")</button></a>
 </div>
 
-<a href="@{routes.AddressLookupController.edit(id,Some(lookup.postcode),Some(true))}" id="enterManual">@messages("results.manual.entry.text")</a>
+<a href="@{routes.AddressLookupController.edit(id,Some(lookup.postcode),journeyData.resolvedConfig.cfg.ukMode)}" id="enterManual">@messages("results.manual.entry.text")</a>
 
 }

--- a/app/views/ukModeEdit.scala.html
+++ b/app/views/ukModeEdit.scala.html
@@ -58,7 +58,7 @@
       <div class="form-field spaced-below">
         @alfInput(
         editForm("postcode"),
-        '_label -> messages("ukmode.postcode.label"),
+        '_label -> journeyData.resolvedConfig.editPage.postcodeLabel,
         '_inputClass -> "form-control--block input--small"
         )
       </div>

--- a/app/views/v2/no_results.scala.html
+++ b/app/views/v2/no_results.scala.html
@@ -22,7 +22,7 @@
 
 @helpers.form(controllers.routes.AddressLookupController.lookup(id)) {
 <div class="form-group">
-    <a href="@{routes.AddressLookupController.edit(id,None,Some(true))}" id="enterManual">@{messageConstants.noResultsPageEnterManually}</a>
+    <a href="@{routes.AddressLookupController.edit(id,None,Some(journeyData.resolveConfigV2(isWelsh).options.isUkMode))}" id="enterManual">@{messageConstants.noResultsPageEnterManually}</a>
 </div>
 
 <div class="form-group">

--- a/app/views/v2/too_many_results.scala.html
+++ b/app/views/v2/too_many_results.scala.html
@@ -42,5 +42,5 @@
         </a>
     </div>
 
-    <a href="@{routes.AddressLookupController.edit(id,None,Some(journeyData.resolveConfigV2(isWelsh).options.isUkMode))}" id="enterManual">@messageConstants.tooManyResultsManualLink</a>
+    <a href="@{routes.AddressLookupController.edit(id,Some(lookup.postcode),Some(journeyData.resolveConfigV2(isWelsh).options.isUkMode))}" id="enterManual">@messageConstants.tooManyResultsManualLink</a>
 }

--- a/app/views/v2/too_many_results.scala.html
+++ b/app/views/v2/too_many_results.scala.html
@@ -31,10 +31,10 @@
     <p>@messageConstants.youEntered</p>
     <ul class="list list-bullet">
         <li>@{lookup.postcode} @messageConstants.forPostcode</li>
-        <li>@{lookup.filter.fold(messageConstants.nothingText)(filter => s"'${filter}' ${messageConstants.nameNumberText}")}</li>
+        <li>@{lookup.filter.fold(messageConstants.nothingText)(filter => s"'$filter' ${messageConstants.nameNumberText}")}</li>
 
     </ul>
-    </br>
+    <br />
 
     <div class="form-group">
         <a id="anotherSearch" class="button" href="@{routes.AddressLookupController.lookup(id,Some(lookup.postcode),lookup.filter)}">
@@ -42,5 +42,5 @@
         </a>
     </div>
 
-    <a href="@{routes.AddressLookupController.edit(id,Some(lookup.postcode),Some(true))}" id="enterManual">@messageConstants.tooManyResultsManualLink</a>
+    <a href="@{routes.AddressLookupController.edit(id,None,Some(journeyData.resolveConfigV2(isWelsh).options.isUkMode))}" id="enterManual">@messageConstants.tooManyResultsManualLink</a>
 }

--- a/app/views/v2/uk_mode_edit.scala.html
+++ b/app/views/v2/uk_mode_edit.scala.html
@@ -72,7 +72,7 @@
       <div class="form-field spaced-below">
         @alfInput(
         editForm("postcode"),
-        '_label -> messageConstants.ukModePostcodeLabel,
+        '_label -> resolvedConf.labels.editPageLabels.postcodeLabel,
         '_inputClass -> "form-control--block input--small",
         '_autoComplete -> "postal-code"
         )

--- a/it/controllers/EditPageISpec.scala
+++ b/it/controllers/EditPageISpec.scala
@@ -1,9 +1,9 @@
 package controllers
 
-import config.FrontendAppConfig.ALFCookieNames
 import itutil.IntegrationSpecBase
 import itutil.config.IntegrationTestConstants._
 import itutil.config.PageElementConstants.{EditPage, _}
+import model.MessageConstants.{EnglishMessageConstants => EnglishMessages, WelshMessageConstants => WelshMessages}
 import model.{EditPage => _, LookupPage => _, _}
 import org.jsoup.Jsoup
 import play.api.http.HeaderNames
@@ -11,7 +11,6 @@ import play.api.http.Status._
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.FakeApplication
 import uk.gov.hmrc.address.v2.Country
-import model.MessageConstants.{EnglishMessageConstants => EnglishMessages, WelshMessageConstants => WelshMessages}
 
 class EditPageISpec extends IntegrationSpecBase {
 
@@ -130,7 +129,7 @@ class EditPageISpec extends IntegrationSpecBase {
       "return non uk edit and not error with showSearchAgainLink and searchAgainLinkText in the json should not error when uk param not provided" in {
         val config = (Json.toJson(journeyDataV2Minimal).as[JsObject] - "editPage") ++
           Json.obj("editPage" -> Json.obj("showSearchAgainLink" -> true, "searchAgainLinkText" -> "foo"))
-        stubKeystore(testJourneyId, testConfigDefaultAsJson, OK)
+        stubKeystore(testJourneyId, Json.toJson(config).as[JsObject], OK)
 
         val fResponse = buildClientLookupAddress(path = "edit?uk=false")
           .withHeaders(HeaderNames.COOKIE -> sessionCookieWithCSRF,
@@ -143,9 +142,6 @@ class EditPageISpec extends IntegrationSpecBase {
       }
 
       "return the UK edit page with no pre-popped postcode if param not provided AND UK mode is false but uk param provided" in {
-        val testConfigWithAddressAndNotUkMode = journeyDataV2Minimal.copy(
-          selectedAddress = None, config = journeyDataV2Minimal.config.copy(options = journeyDataV2Minimal.config.options.copy(ukMode = Some(false))))
-
         stubKeystore(testJourneyId, journeyDataV2WithSelectedAddressJson(), OK)
         val fResponse = buildClientLookupAddress(path = "edit?uk=true")
           .withHeaders(HeaderNames.COOKIE -> sessionCookieWithCSRF,

--- a/it/controllers/NoResultsFoundPageISpec.scala
+++ b/it/controllers/NoResultsFoundPageISpec.scala
@@ -56,7 +56,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
         )
 
         doc.link("enterManual") should have(
-          href(routes.AddressLookupController.edit(testJourneyId, None, Some(true)).url),
+          href(routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url),
           text(EnglishContent.manualEntry)
         )
 
@@ -122,7 +122,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
         )
 
         doc.link("enterManual") should have(
-          href(routes.AddressLookupController.edit(testJourneyId, None, Some(true)).url),
+          href(routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url),
           text(EnglishContent.manualEntry)
         )
 
@@ -156,7 +156,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
         )
 
         doc.link("enterManual") should have(
-          href(routes.AddressLookupController.edit(testJourneyId, None, Some(true)).url),
+          href(routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url),
           text(WelshContent.manualEntry)
         )
 
@@ -202,7 +202,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
           )
 
         doc.link("enterManual") should have(
-          href(routes.AddressLookupController.edit(testJourneyId, None, Some(true)).url),
+          href(routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url),
           text(EnglishContent.manualEntry)
         )
 

--- a/it/controllers/TooManyResultsISpec.scala
+++ b/it/controllers/TooManyResultsISpec.scala
@@ -4,7 +4,6 @@ import itutil.config.AddressRecordConstants._
 import itutil.config.IntegrationTestConstants._
 import itutil.{IntegrationSpecBase, PageContentHelper}
 import model.JourneyConfigDefaults.EnglishConstants
-import model.MessageConstants.WelshMessageConstants
 import model.{JourneyConfigDefaults, JourneyLabels, LanguageLabels}
 import play.api.http.HeaderNames
 import play.api.http.Status._
@@ -80,7 +79,10 @@ class TooManyResultsISpec extends IntegrationSpecBase with PageContentHelper {
             doc.bulletPointList.select("li").first.text shouldBe tooManyResultsMessages.bullet1(testPostCode)
             doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2NoFilter
             doc.link("anotherSearch").text() shouldBe tooManyResultsMessages.button
-            doc.link("enterManual").text shouldBe EDIT_LINK_TEXT
+            doc.link("enterManual") should have(
+              href(routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url),
+              text(EDIT_LINK_TEXT)
+            )
           }
         }
 
@@ -108,7 +110,10 @@ class TooManyResultsISpec extends IntegrationSpecBase with PageContentHelper {
             doc.bulletPointList.select("li").first.text shouldBe tooManyResultsMessages.bullet1(testPostCode)
             doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2WithFilter(testFilterValue)
             doc.link("anotherSearch").text() shouldBe tooManyResultsMessages.button
-            doc.link("enterManual").text shouldBe EDIT_LINK_TEXT
+            doc.link("enterManual") should have(
+              href(routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url),
+              text(EDIT_LINK_TEXT)
+            )
           }
         }
       }
@@ -136,7 +141,10 @@ class TooManyResultsISpec extends IntegrationSpecBase with PageContentHelper {
             doc.bulletPointList.select("li").first.text shouldBe tooManyResultsMessages.bullet1(testPostCode)
             doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2NoFilter
             doc.link("anotherSearch").text() shouldBe tooManyResultsMessages.button
-            doc.link("enterManual").text shouldBe EDIT_LINK_TEXT
+            doc.link("enterManual") should have(
+              href(routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url),
+              text(EDIT_LINK_TEXT)
+            )
           }
         }
 
@@ -164,7 +172,10 @@ class TooManyResultsISpec extends IntegrationSpecBase with PageContentHelper {
             doc.bulletPointList.select("li").first.text shouldBe tooManyResultsMessages.bullet1(testPostCode)
             doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2WithFilter(testFilterValue)
             doc.link("anotherSearch").text() shouldBe tooManyResultsMessages.button
-            doc.link("enterManual").text shouldBe EDIT_LINK_TEXT
+            doc.link("enterManual") should have(
+              href(routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url),
+              text(EDIT_LINK_TEXT)
+            )
           }
         }
       }
@@ -197,7 +208,10 @@ class TooManyResultsISpec extends IntegrationSpecBase with PageContentHelper {
           doc.bulletPointList.select("li").first.text shouldBe welshTooManyResultsMessages.bullet1(testPostCode)
           doc.bulletPointList.select("li").last.text shouldBe welshTooManyResultsMessages.bullet2WithFilter(testFilterValue)
           doc.link("anotherSearch").text() shouldBe welshTooManyResultsMessages.button
-          doc.link("enterManual").text() shouldBe JourneyConfigDefaults.WelshConstants(true).EDIT_LINK_TEXT
+          doc.link("enterManual") should have(
+            href(routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url),
+            text(JourneyConfigDefaults.WelshConstants(true).EDIT_LINK_TEXT)
+          )
         }
       }
 
@@ -230,7 +244,10 @@ class TooManyResultsISpec extends IntegrationSpecBase with PageContentHelper {
           doc.bulletPointList.select("li").first.text shouldBe welshTooManyResultsMessages.bullet1(testPostCode)
           doc.bulletPointList.select("li").last.text shouldBe welshTooManyResultsMessages.bullet2WithFilter(testFilterValue)
           doc.link("anotherSearch").text() shouldBe welshTooManyResultsMessages.button
-          doc.link("enterManual").text() shouldBe JourneyConfigDefaults.WelshConstants(true).EDIT_LINK_TEXT
+          doc.link("enterManual") should have(
+            href(routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url),
+            text(JourneyConfigDefaults.WelshConstants(true).EDIT_LINK_TEXT)
+          )
         }
       }
     }

--- a/it/itutil/config/IntegrationTestConstants.scala
+++ b/it/itutil/config/IntegrationTestConstants.scala
@@ -712,6 +712,8 @@ object IntegrationTestConstants {
       )
     )
 
+  val journeyDataV2ResultLimitUkMode: JourneyDataV2 = JourneyDataV2(JourneyConfigV2(2, JourneyOptions(testContinueUrl, selectPageConfig = Some(SelectPageConfig(proposalListLimit = Some(50))), ukMode = Some(true))))
+  val journeyDataV2MinimalUkMode: JourneyDataV2 = JourneyDataV2(JourneyConfigV2(2, JourneyOptions(testContinueUrl, ukMode = Some(true))))
   val journeyDataV2ResultLimit: JourneyDataV2 = JourneyDataV2(JourneyConfigV2(2, JourneyOptions(testContinueUrl, selectPageConfig = Some(SelectPageConfig(proposalListLimit = Some(50))))))
   val journeyDataV2Minimal: JourneyDataV2 = JourneyDataV2(JourneyConfigV2(2, JourneyOptions(testContinueUrl)))
 

--- a/test/utils/TestConstants.scala
+++ b/test/utils/TestConstants.scala
@@ -195,6 +195,8 @@ object TestConstants {
 
   val fullV2JourneyData = JourneyDataV2(fullV2JourneyConfig, Some(testProposedAddressSeq), Some(testAddress), Some(testAddress))
 
+  val fullV2JourneyDataNonUkMode = JourneyDataV2(fullV2JourneyConfig.copy(options = fullV2JourneyOptions.copy(ukMode = Some(false))), Some(testProposedAddressSeq), Some(testAddress), Some(testAddress))
+
   val fullV2JourneyDataFromV1 = JourneyDataV2(fullV2JourneyConfig.copy(requestedVersion = Some(1), options = fullV2JourneyOptions.copy(disableTranslations = Some(false))), Some(testProposedAddressSeq), Some(testAddress), Some(testAddress))
 
   val emptyJson: JsValue = Json.parse("{}")
@@ -563,10 +565,31 @@ object TestConstants {
     )
   )
 
+  val journeyDataV2MinimalUKMode = JourneyDataV2(
+    config = JourneyConfigV2(
+      version = 2,
+      options = JourneyOptions(
+        continueUrl = "testContinueUrl",
+        ukMode = Some(true)
+      )
+    )
+  )
+
   val journeyDataV2EnglishAndWelshMinimal = JourneyDataV2(
     config = JourneyConfigV2(
       version = 2,
       options = JourneyOptions(continueUrl = "testContinueUrl"),
+      labels = Some(JourneyLabels(
+        en = Some(LanguageLabels()),
+        cy = Some(LanguageLabels())
+      ))
+    )
+  )
+
+  val journeyDataV2EnglishAndWelshMinimalUKMode = JourneyDataV2(
+    config = JourneyConfigV2(
+      version = 2,
+      options = JourneyOptions(continueUrl = "testContinueUrl", ukMode = Some(true)),
       labels = Some(JourneyLabels(
         en = Some(LanguageLabels()),
         cy = Some(LanguageLabels())

--- a/test/views/NoResultsV1ViewSpec.scala
+++ b/test/views/NoResultsV1ViewSpec.scala
@@ -1,0 +1,55 @@
+package views
+
+import controllers.routes
+import org.jsoup.Jsoup
+import play.api.i18n.Messages.Implicits._
+import play.api.i18n.MessagesApi
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import utils.TestConstants._
+import views.html.no_results
+
+class NoResultsV1ViewSpec extends ViewSpec {
+
+  implicit val testRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+  implicit val messages = app.injector.instanceOf[MessagesApi]
+
+  object EnglishContent {
+    val title = "We can not find any addresses"
+    def heading(postcode: String) = s"We can not find any addresses for $postcode"
+    val back = "Back"
+    val tryAgainButton = "Try a different postcode"
+    val enterManualLink = "Enter the address manually"
+  }
+
+  "The 'No results' view" when {
+    "rendered with the default English config" should {
+      "Render the view and display the Back button with UK Mode = false" in {
+        val noResultsView = no_results(id = testJourneyId, journeyData = fullV1JourneyData.copy(config = fullV1JourneyConfig.copy(ukMode = Some(false))), postcode = testPostCode)
+        val doc = Jsoup.parse(noResultsView.body)
+
+        doc.title shouldBe EnglishContent.title
+        doc.getBackLinkText shouldBe EnglishContent.back
+        doc.getH1ElementAsText shouldBe EnglishContent.heading(testPostCode)
+        doc.getButtonContentAsText shouldBe EnglishContent.tryAgainButton
+        doc.getALinkText("enterManual") shouldBe EnglishContent.enterManualLink
+        doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
+      }
+    }
+
+    "rendered with the default English config (UK Mode = true)" should {
+      "Render the view and display the Back button with UK Mode = true" in {
+        val noResultsView = no_results(id = testJourneyId, journeyData = fullV1JourneyData, postcode = testPostCode)
+        val doc = Jsoup.parse(noResultsView.body)
+
+        doc.title shouldBe EnglishContent.title
+        doc.getBackLinkText shouldBe EnglishContent.back
+        doc.getH1ElementAsText shouldBe EnglishContent.heading(testPostCode)
+        doc.getButtonContentAsText shouldBe EnglishContent.tryAgainButton
+        doc.getALinkText("enterManual") shouldBe EnglishContent.enterManualLink
+        doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(true)).url
+      }
+    }
+  }
+
+}

--- a/test/views/NoResultsViewSpec.scala
+++ b/test/views/NoResultsViewSpec.scala
@@ -1,12 +1,11 @@
 package views
 
 import controllers.routes
-import model.{JourneyConfigV2, JourneyDataV2, JourneyOptions}
 import org.jsoup.Jsoup
-import play.api.test.FakeRequest
 import play.api.i18n.Messages.Implicits._
 import play.api.i18n.MessagesApi
 import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
 import utils.TestConstants._
 import views.html.v2.no_results
 
@@ -42,6 +41,20 @@ class NoResultsViewSpec extends ViewSpec {
         doc.getH1ElementAsText shouldBe EnglishContent.heading(testPostCode)
         doc.getButtonContentAsText shouldBe EnglishContent.tryAgainButton
         doc.getALinkText("enterManual") shouldBe EnglishContent.enterManualLink
+        doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
+      }
+    }
+
+    "rendered with the default English config (UK Mode = true)" should {
+      "Render the view and display the Back button with UK Mode = true" in {
+        val noResultsView = no_results(id = testJourneyId, journeyData = journeyDataV2MinimalUKMode, postcode = testPostCode)
+        val doc = Jsoup.parse(noResultsView.body)
+
+        doc.title shouldBe EnglishContent.title
+        doc.getBackLinkText shouldBe EnglishContent.back
+        doc.getH1ElementAsText shouldBe EnglishContent.heading(testPostCode)
+        doc.getButtonContentAsText shouldBe EnglishContent.tryAgainButton
+        doc.getALinkText("enterManual") shouldBe EnglishContent.enterManualLink
         doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(true)).url
       }
     }
@@ -56,13 +69,25 @@ class NoResultsViewSpec extends ViewSpec {
         doc.getH1ElementAsText shouldBe EnglishContent.heading(testPostCode)
         doc.getButtonContentAsText shouldBe EnglishContent.tryAgainButton
         doc.getALinkText("enterManual") shouldBe EnglishContent.enterManualLink
-        doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(true)).url
+        doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
       }
     }
 
     "rendered with the default Welsh config" should {
       "Render the view and display the Back button" in {
         val noResultsView = no_results(id = testJourneyId, journeyData = journeyDataV2EnglishAndWelshMinimal, postcode = testPostCode, isWelsh = true)
+        val doc = Jsoup.parse(noResultsView.body)
+
+        doc.title shouldBe WelshContent.title
+        doc.getBackLinkText shouldBe WelshContent.back
+        doc.getH1ElementAsText shouldBe WelshContent.heading(testPostCode)
+        doc.getButtonContentAsText shouldBe WelshContent.tryAgainButton
+        doc.getALinkText("enterManual") shouldBe WelshContent.enterManualLink
+        doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
+      }
+
+      "Render the view and display the Back button with UK Mode = true" in {
+        val noResultsView = no_results(id = testJourneyId, journeyData = journeyDataV2EnglishAndWelshMinimalUKMode, postcode = testPostCode, isWelsh = true)
         val doc = Jsoup.parse(noResultsView.body)
 
         doc.title shouldBe WelshContent.title

--- a/test/views/NonUKModeEditViewSpec.scala
+++ b/test/views/NonUKModeEditViewSpec.scala
@@ -8,7 +8,6 @@ import org.jsoup.nodes.Document
 import play.api.i18n.MessagesApi
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import play.twirl.api.Html
 import utils.TestConstants._
 
 
@@ -42,6 +41,7 @@ class NonUKModeEditViewSpec extends ViewSpec {
   implicit val testRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
   val messages = app.injector.instanceOf[MessagesApi]
   val configWithoutLabels = fullV2JourneyConfig.copy(
+    options = fullV2JourneyOptions.copy(ukMode = Some(false)),
     labels = Some(JourneyLabels(
       en = Some(fullV2LanguageLabelsEn.copy(editPageLabels = None))
     )))
@@ -51,10 +51,10 @@ class NonUKModeEditViewSpec extends ViewSpec {
 
       val testPage = views.html.v2.non_uk_mode_edit(
         id = testId,
-        journeyData = fullV2JourneyData.copy(config = configWithoutLabels),
+        journeyData = fullV2JourneyDataNonUkMode.copy(config = configWithoutLabels),
         editForm = nonUkEditForm(false),
         countries = Seq("FR" -> "France"),
-        false
+        isWelsh = false
       )
       val doc: Document = Jsoup.parse(testPage.body)
 
@@ -83,10 +83,10 @@ class NonUKModeEditViewSpec extends ViewSpec {
     "when provided with page config" in {
       val testPage = views.html.v2.non_uk_mode_edit(
         id = testId,
-        journeyData = fullV2JourneyData,
+        journeyData = fullV2JourneyDataNonUkMode,
         editForm = nonUkEditForm(false),
         countries = Seq("FR" -> "France"),
-        false
+        isWelsh = false
       )
       val doc: Document = Jsoup.parse(testPage.body)
 
@@ -115,10 +115,10 @@ class NonUKModeEditViewSpec extends ViewSpec {
     "When there is > 1 country" in {
       val testPage = views.html.v2.non_uk_mode_edit(
         id = testId,
-        journeyData = fullV2JourneyData.copy(config = configWithoutLabels),
+        journeyData = fullV2JourneyDataNonUkMode.copy(config = configWithoutLabels),
         editForm = nonUkEditForm(false),
         countries = Seq("FR" -> "France", "AL" -> "Albanian"),
-        false
+        isWelsh = false
       )
       val doc: Document = Jsoup.parse(testPage.body)
 

--- a/test/views/TooManyResultsV1ViewSpec.scala
+++ b/test/views/TooManyResultsV1ViewSpec.scala
@@ -1,0 +1,112 @@
+package views
+
+import controllers.routes
+import model.JourneyConfigDefaults
+import org.jsoup.Jsoup
+import play.api.i18n.Messages.Implicits._
+import play.api.i18n.MessagesApi
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import utils.TestConstants._
+
+class TooManyResultsV1ViewSpec extends ViewSpec {
+  implicit val testRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+  implicit val messages = app.injector.instanceOf[MessagesApi]
+
+  val testHtml = Html("")
+
+  object tooManyResultsMessages {
+    val title = "No results found"
+    val heading1 = "There are too many results"
+    val heading2 = "We couldn't find any results for that property name or number"
+
+    def bullet1(postcode: String) = s"$postcode for postcode"
+
+    val bullet2NoFilter = "nothing for property name or number"
+
+    def bullet2WithFilter(filter: String) = s"'$filter' for name or number"
+
+    val line1 = "You entered:"
+    val back = "Back"
+  }
+
+  val EnglishConstantsUkMode = JourneyConfigDefaults.EnglishConstants(true)
+
+  "The English 'Too Many Results' page" should {
+    "be rendered" when {
+      "the back buttons are enabled in the journey config" when {
+        "no filter has been entered" when {
+          "there are too many addresses" in {
+            val doc = Jsoup.parse(views.html.too_many_results(
+              id = testJourneyId,
+              journeyData = fullV1JourneyData,
+              lookup = model.Lookup(
+                None,
+                testPostCode
+              ),
+              firstLookup = true
+            ).body)
+
+            doc.getBackLinkText shouldBe tooManyResultsMessages.back
+            doc.title shouldBe tooManyResultsMessages.title
+            doc.getH1ElementAsText shouldBe tooManyResultsMessages.heading1
+            doc.paras.not(".language-select").get(2).text shouldBe tooManyResultsMessages.line1
+            System.out.println(doc)
+            doc.bulletPointList.select("li").first.text shouldBe tooManyResultsMessages.bullet1(testPostCode)
+            doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2NoFilter
+            doc.getALinkText("enterManual") shouldBe EnglishConstantsUkMode.EDIT_LINK_TEXT
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, Some(testPostCode), Some(true)).url
+          }
+        }
+
+        "a filter has been entered with ukMode = false" when {
+          "there are too many addresses" in {
+            val doc = Jsoup.parse(views.html.too_many_results(
+              id = testJourneyId,
+              journeyData = fullV1JourneyData.copy(config = fullV1JourneyConfig.copy(ukMode = Some(false))),
+              lookup = model.Lookup(
+                Some(testFilterValue),
+                testPostCode
+              ),
+              firstLookup = false
+            ).body)
+
+            doc.getBackLinkText shouldBe tooManyResultsMessages.back
+            doc.title shouldBe tooManyResultsMessages.title
+            doc.getH1ElementAsText shouldBe tooManyResultsMessages.heading2
+            doc.paras.not(".language-select").get(2).text shouldBe tooManyResultsMessages.line1
+            doc.bulletPointList.select("li").first.text shouldBe tooManyResultsMessages.bullet1(testPostCode)
+            doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2WithFilter(testFilterValue)
+            doc.getALinkText("enterManual") shouldBe EnglishConstantsUkMode.EDIT_LINK_TEXT
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, Some(testPostCode), Some(false)).url
+          }
+        }
+
+        "a filter has been entered with ukMode = true" when {
+          "there are too many addresses" in {
+            val doc = Jsoup.parse(views.html.too_many_results(
+              id = testJourneyId,
+              journeyData = fullV1JourneyData,
+              lookup = model.Lookup(
+                Some(testFilterValue),
+                testPostCode
+              ),
+              firstLookup = false
+            ).body)
+
+            doc.getBackLinkText shouldBe tooManyResultsMessages.back
+            doc.title shouldBe tooManyResultsMessages.title
+            doc.getH1ElementAsText shouldBe tooManyResultsMessages.heading2
+            doc.paras.not(".language-select").get(2).text shouldBe tooManyResultsMessages.line1
+            doc.bulletPointList.select("li").first.text shouldBe tooManyResultsMessages.bullet1(testPostCode)
+            doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2WithFilter(testFilterValue)
+            doc.getALinkText("enterManual") shouldBe EnglishConstantsUkMode.EDIT_LINK_TEXT
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, Some(testPostCode), Some(true)).url
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/test/views/TooManyResultsViewSpec.scala
+++ b/test/views/TooManyResultsViewSpec.scala
@@ -1,6 +1,6 @@
 package views
 
-import model.MessageConstants.{EnglishMessageConstants, WelshMessageConstants}
+import controllers.routes
 import model.{JourneyConfigDefaults, JourneyConfigV2, JourneyDataV2, JourneyOptions}
 import org.jsoup.Jsoup
 import play.api.i18n.Messages.Implicits._
@@ -48,12 +48,13 @@ class TooManyResultsViewSpec extends ViewSpec {
     val back = "Yn ôl"
   }
 
-  def journeyData(showBackButtons: Boolean) = JourneyDataV2(
+  def journeyData(showBackButtons: Boolean, ukMode: Option[Boolean] = None) = JourneyDataV2(
     JourneyConfigV2(
       2,
       JourneyOptions(
         continueUrl = testContinueUrl,
-        showBackButtons = Some(showBackButtons)
+        showBackButtons = Some(showBackButtons),
+        ukMode = ukMode
       )
     )
   )
@@ -73,8 +74,7 @@ class TooManyResultsViewSpec extends ViewSpec {
                 None,
                 testPostCode
               ),
-              firstLookup = true,
-              isWelsh = false
+              firstLookup = true
             ).body)
 
             doc.getBackLinkText shouldBe tooManyResultsMessages.back
@@ -85,6 +85,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2NoFilter
             doc.getALinkText("anotherSearch") shouldBe tooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe EnglishConstantsUkMode.EDIT_LINK_TEXT
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
           }
         }
 
@@ -97,8 +98,7 @@ class TooManyResultsViewSpec extends ViewSpec {
                 Some(testFilterValue),
                 testPostCode
               ),
-              firstLookup = false,
-              isWelsh = false
+              firstLookup = false
             ).body)
 
             doc.getBackLinkText shouldBe tooManyResultsMessages.back
@@ -109,6 +109,31 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2WithFilter(testFilterValue)
             doc.getALinkText("anotherSearch") shouldBe tooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe EnglishConstantsUkMode.EDIT_LINK_TEXT
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
+          }
+        }
+
+        "a filter has been entered with ukMode = true" when {
+          "there are too many addresses" in {
+            val doc = Jsoup.parse(views.html.v2.too_many_results(
+              id = testJourneyId,
+              journeyData = journeyData(showBackButtons = true, ukMode = Some(true)),
+              lookup = model.Lookup(
+                Some(testFilterValue),
+                testPostCode
+              ),
+              firstLookup = false
+            ).body)
+
+            doc.getBackLinkText shouldBe tooManyResultsMessages.back
+            doc.title shouldBe tooManyResultsMessages.title
+            doc.getH1ElementAsText shouldBe tooManyResultsMessages.heading2
+            doc.paras.not(".language-select").get(1).text shouldBe tooManyResultsMessages.line1
+            doc.bulletPointList.select("li").first.text shouldBe tooManyResultsMessages.bullet1(testPostCode)
+            doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2WithFilter(testFilterValue)
+            doc.getALinkText("anotherSearch") shouldBe tooManyResultsMessages.button
+            doc.getALinkText("enterManual") shouldBe EnglishConstantsUkMode.EDIT_LINK_TEXT
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(true)).url
           }
         }
       }
@@ -123,8 +148,7 @@ class TooManyResultsViewSpec extends ViewSpec {
                 None,
                 testPostCode
               ),
-              firstLookup = true,
-              isWelsh = false
+              firstLookup = true
             ).body)
 
             doc.getBackLinkText shouldBe empty
@@ -135,6 +159,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2NoFilter
             doc.getALinkText("anotherSearch") shouldBe tooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe EnglishConstantsUkMode.EDIT_LINK_TEXT
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
           }
         }
 
@@ -147,8 +172,7 @@ class TooManyResultsViewSpec extends ViewSpec {
                 Some(testFilterValue),
                 testPostCode
               ),
-              firstLookup = false,
-              isWelsh = false
+              firstLookup = false
             ).body)
 
             doc.getBackLinkText shouldBe empty
@@ -159,6 +183,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2WithFilter(testFilterValue)
             doc.getALinkText("anotherSearch") shouldBe tooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe EnglishConstantsUkMode.EDIT_LINK_TEXT
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
           }
         }
       }
@@ -189,6 +214,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe welshTooManyResultsMessages.bullet2NoFilter
             doc.getALinkText("anotherSearch") shouldBe welshTooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe WelshConstantsUkMode.EDIT_LINK_TEXT
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
           }
         }
 
@@ -213,6 +239,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe welshTooManyResultsMessages.bullet2WithFilter(testFilterValue)
             doc.getALinkText("anotherSearch") shouldBe welshTooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe WelshConstantsUkMode.EDIT_LINK_TEXT
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
           }
         }
       }
@@ -239,6 +266,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe welshTooManyResultsMessages.bullet2NoFilter
             doc.getALinkText("anotherSearch") shouldBe welshTooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe WelshConstantsUkMode.EDIT_LINK_TEXT
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
           }
         }
 
@@ -263,6 +291,32 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe welshTooManyResultsMessages.bullet2WithFilter(testFilterValue)
             doc.getALinkText("anotherSearch") shouldBe welshTooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe WelshConstantsUkMode.EDIT_LINK_TEXT
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
+          }
+        }
+
+        "a filter has been entered with ukMode = true" when {
+          "there are too many addresses" in {
+            val doc = Jsoup.parse(views.html.v2.too_many_results(
+              id = testJourneyId,
+              journeyData = journeyData(showBackButtons = false, ukMode = Some(true)),
+              lookup = model.Lookup(
+                Some(testFilterValue),
+                testPostCode
+              ),
+              firstLookup = false,
+              isWelsh = true
+            ).body)
+
+            doc.getBackLinkText shouldBe empty
+            doc.title shouldBe welshTooManyResultsMessages.title
+            doc.getH1ElementAsText shouldBe welshTooManyResultsMessages.heading2
+            doc.paras.not(".language-select").get(1).text shouldBe welshTooManyResultsMessages.line1
+            doc.bulletPointList.select("li").first.text shouldBe welshTooManyResultsMessages.bullet1(testPostCode)
+            doc.bulletPointList.select("li").last.text shouldBe welshTooManyResultsMessages.bullet2WithFilter(testFilterValue)
+            doc.getALinkText("anotherSearch") shouldBe welshTooManyResultsMessages.button
+            doc.getALinkText("enterManual") shouldBe WelshConstantsUkMode.EDIT_LINK_TEXT
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(true)).url
           }
         }
       }

--- a/test/views/TooManyResultsViewSpec.scala
+++ b/test/views/TooManyResultsViewSpec.scala
@@ -85,7 +85,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2NoFilter
             doc.getALinkText("anotherSearch") shouldBe tooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe EnglishConstantsUkMode.EDIT_LINK_TEXT
-            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, Some(testPostCode), Some(false)).url
           }
         }
 
@@ -109,7 +109,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2WithFilter(testFilterValue)
             doc.getALinkText("anotherSearch") shouldBe tooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe EnglishConstantsUkMode.EDIT_LINK_TEXT
-            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, Some(testPostCode), Some(false)).url
           }
         }
 
@@ -133,7 +133,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2WithFilter(testFilterValue)
             doc.getALinkText("anotherSearch") shouldBe tooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe EnglishConstantsUkMode.EDIT_LINK_TEXT
-            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(true)).url
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, Some(testPostCode), Some(true)).url
           }
         }
       }
@@ -159,7 +159,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2NoFilter
             doc.getALinkText("anotherSearch") shouldBe tooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe EnglishConstantsUkMode.EDIT_LINK_TEXT
-            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, Some(testPostCode), Some(false)).url
           }
         }
 
@@ -183,7 +183,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe tooManyResultsMessages.bullet2WithFilter(testFilterValue)
             doc.getALinkText("anotherSearch") shouldBe tooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe EnglishConstantsUkMode.EDIT_LINK_TEXT
-            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, Some(testPostCode), Some(false)).url
           }
         }
       }
@@ -214,7 +214,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe welshTooManyResultsMessages.bullet2NoFilter
             doc.getALinkText("anotherSearch") shouldBe welshTooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe WelshConstantsUkMode.EDIT_LINK_TEXT
-            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, Some(testPostCode), Some(false)).url
           }
         }
 
@@ -239,7 +239,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe welshTooManyResultsMessages.bullet2WithFilter(testFilterValue)
             doc.getALinkText("anotherSearch") shouldBe welshTooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe WelshConstantsUkMode.EDIT_LINK_TEXT
-            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, Some(testPostCode), Some(false)).url
           }
         }
       }
@@ -266,7 +266,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe welshTooManyResultsMessages.bullet2NoFilter
             doc.getALinkText("anotherSearch") shouldBe welshTooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe WelshConstantsUkMode.EDIT_LINK_TEXT
-            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, Some(testPostCode), Some(false)).url
           }
         }
 
@@ -291,7 +291,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe welshTooManyResultsMessages.bullet2WithFilter(testFilterValue)
             doc.getALinkText("anotherSearch") shouldBe welshTooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe WelshConstantsUkMode.EDIT_LINK_TEXT
-            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(false)).url
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, Some(testPostCode), Some(false)).url
           }
         }
 
@@ -316,7 +316,7 @@ class TooManyResultsViewSpec extends ViewSpec {
             doc.bulletPointList.select("li").last.text shouldBe welshTooManyResultsMessages.bullet2WithFilter(testFilterValue)
             doc.getALinkText("anotherSearch") shouldBe welshTooManyResultsMessages.button
             doc.getALinkText("enterManual") shouldBe WelshConstantsUkMode.EDIT_LINK_TEXT
-            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, None, Some(true)).url
+            doc.getLinkHrefAsText("enterManual") shouldBe routes.AddressLookupController.edit(testJourneyId, Some(testPostCode), Some(true)).url
           }
         }
       }

--- a/test/views/UKModeEditViewSpec.scala
+++ b/test/views/UKModeEditViewSpec.scala
@@ -1,18 +1,41 @@
 package views
 
-import model._
 import forms.ALFForms._
+import model._
 import org.jsoup.Jsoup
-import play.api.i18n.Messages.Implicits._
 import org.jsoup.nodes.Document
+import play.api.i18n.Messages.Implicits._
 import play.api.i18n.MessagesApi
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import play.twirl.api.Html
 import utils.TestConstants._
 
 
 class UKModeEditViewSpec extends ViewSpec {
+
+  object customContent {
+    val title = "Custom Enter address"
+    val heading = "Custom Enter address"
+    val addressLine1 = "Custom Address line 1"
+    val addressLine2 = "Custom Address line 2 (optional)"
+    val addressLine3 = "Custom Address line 3 (optional)"
+    val townCity = "Custom Town/city"
+    val postcodeUk ="Custom UK postcode (optional)"
+    val country = "Custom country"
+    val continue = "Custom Continue"
+  }
+
+  object defaultWelshContent {
+    val title = "Nodwch cyfeiriad"
+    val heading = "Nodwch cyfeiriad"
+    val addressLine1 = "Llinell cyfeiriad 1"          
+    val addressLine2 = "Llinell cyfeiriad 2 (dewisol)"
+    val addressLine3 = "Llinell cyfeiriad 3 (dewisol)"
+    val townCity = "Tref/dinas"
+    val postcodeUk ="Cod post y DU (dewisol)"
+    val country = "Gwlad"
+    val continue = "Yn eich blaen"
+  }
 
   object defaultContent {
     val title = "Enter address"
@@ -33,6 +56,7 @@ class UKModeEditViewSpec extends ViewSpec {
     val addressLine2 = "editLine2"
     val addressLine3 = "editLine3"
     val townCity = "editLine4"
+    val postcodeUk ="editPostcode"
     val continue = "editSubmit"
   }
 
@@ -43,6 +67,20 @@ class UKModeEditViewSpec extends ViewSpec {
       en = Some(fullV2LanguageLabelsEn.copy(editPageLabels = None))
     )))
 
+  val configWithCustomLabels = fullV2JourneyConfig.copy(
+    labels = Some(JourneyLabels(
+      en = Some(fullV2LanguageLabelsEn.copy(
+              editPageLabels = Some(EditPageLabels(Some(customContent.title),
+                                                   Some(customContent.heading),
+                                                   Some(customContent.addressLine1),
+                                                   Some(customContent.addressLine2),
+                                                   Some(customContent.addressLine3),
+                                                   Some(customContent.townCity),
+                                                   Some(customContent.postcodeUk),
+                                                   Some(customContent.country),
+                                                   Some(customContent.continue))))
+    ))))
+
   "UK Mode Page" should {
     "when provided with no page config" in {
 
@@ -51,7 +89,7 @@ class UKModeEditViewSpec extends ViewSpec {
         journeyData = fullV2JourneyData.copy(config = configWithoutLabels),
         editForm = ukEditForm(false),
         countries = Seq("FR" -> "France"),
-        false
+        isWelsh = false
       )
       val doc: Document = Jsoup.parse(testPage.body)
 
@@ -82,7 +120,7 @@ class UKModeEditViewSpec extends ViewSpec {
       journeyData = fullV2JourneyData,
       editForm = ukEditForm(false),
       countries = Seq("FR" -> "France"),
-      false
+      isWelsh = false
     )
     val doc: Document = Jsoup.parse(testPage.body)
 
@@ -100,7 +138,70 @@ class UKModeEditViewSpec extends ViewSpec {
     doc.getTextFieldLabel("town") shouldBe configuredContent.townCity
     doc.getTextFieldInput("town").`val`() shouldBe ""
 
+    doc.getTextFieldLabel("postcode") shouldBe configuredContent.postcodeUk
+    doc.getTextFieldInput("postcode").`val`() shouldBe ""
+
     doc.getElementById("continue").text() shouldBe configuredContent.continue
+  }
+
+  "when provided with custom page config" in {
+    val testPage = views.html.v2.uk_mode_edit(
+      id = testId,
+      journeyData = fullV2JourneyData.copy(config = configWithCustomLabels),
+      editForm = ukEditForm(false),
+      countries = Seq("FR" -> "France"),
+      isWelsh = false
+    )
+    val doc: Document = Jsoup.parse(testPage.body)
+
+    doc.title shouldBe customContent.title
+    doc.getH1ElementAsText shouldBe customContent.heading
+    doc.getTextFieldLabel("line1") shouldBe customContent.addressLine1
+    doc.getTextFieldInput("line1").`val`() shouldBe ""
+
+    doc.getTextFieldLabel("line2") shouldBe customContent.addressLine2
+    doc.getTextFieldInput("line2").`val`() shouldBe ""
+
+    doc.getTextFieldLabel("line3") shouldBe customContent.addressLine3
+    doc.getTextFieldInput("line3").`val`() shouldBe ""
+
+    doc.getTextFieldLabel("town") shouldBe customContent.townCity
+    doc.getTextFieldInput("town").`val`() shouldBe ""
+
+    doc.getTextFieldLabel("postcode") shouldBe customContent.postcodeUk
+    doc.getTextFieldInput("postcode").`val`() shouldBe ""
+
+    doc.getElementById("continue").text() shouldBe customContent.continue
+  }
+
+  "when provided with default page config in Welsh" in {
+    val testPage = views.html.v2.uk_mode_edit(
+      id = testId,
+      journeyData = fullV2JourneyData,
+      editForm = ukEditForm(false),
+      countries = Seq("FR" -> "France"),
+      isWelsh = true
+    )
+    val doc: Document = Jsoup.parse(testPage.body)
+
+    doc.title shouldBe defaultWelshContent.title
+    doc.getH1ElementAsText shouldBe defaultWelshContent.heading
+    doc.getTextFieldLabel("line1") shouldBe defaultWelshContent.addressLine1
+    doc.getTextFieldInput("line1").`val`() shouldBe ""
+
+    doc.getTextFieldLabel("line2") shouldBe defaultWelshContent.addressLine2
+    doc.getTextFieldInput("line2").`val`() shouldBe ""
+
+    doc.getTextFieldLabel("line3") shouldBe defaultWelshContent.addressLine3
+    doc.getTextFieldInput("line3").`val`() shouldBe ""
+
+    doc.getTextFieldLabel("town") shouldBe defaultWelshContent.townCity
+    doc.getTextFieldInput("town").`val`() shouldBe ""
+
+    doc.getTextFieldLabel("postcode") shouldBe defaultWelshContent.postcodeUk
+    doc.getTextFieldInput("postcode").`val`() shouldBe ""
+
+    doc.getElementById("continue").text() shouldBe defaultWelshContent.continue
   }
 
 }


### PR DESCRIPTION
Also remove the fixed label for Postcode on manual address entry (Or Edit Address Page) and use the value from the journey configuration instead.