### PR TITLE
DDS2-1690 DDS2-1687 DDS2-1697 DDS2-1699 - Accessibility fixes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,3 +24,11 @@ nav.hmrc-language-select {
     border: 2px solid #d4351c;
   }
 }
+
+.govuk-back-link{
+  display: none;
+}
+ 
+.js-enabled  .govuk-back-link{
+  display: inline-block;
+}

--- a/app/views/abp/no_results.scala.html
+++ b/app/views/abp/no_results.scala.html
@@ -25,7 +25,7 @@
     journeyData.resolveConfigV2(appConfig)
 }
 
-@page(messages("constants.noResultsPageTitle"), None, journeyData) {
+@page(s"${messages("constants.noResultsPageHeading")} $postcode", None, journeyData) {
 
     <h1 class="@{resolvedConf.options.pageHeadingStyle}" id="pageHeading">
         @{s"${messages("constants.noResultsPageHeading")} $postcode"}

--- a/app/views/abp/non_uk_mode_edit.scala.html
+++ b/app/views/abp/non_uk_mode_edit.scala.html
@@ -60,10 +60,7 @@ select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
 
     @form(routes.AbpAddressLookupController.handleEdit(id)) {
 
-        @govukFieldset(Fieldset(
-            legend = Some(Legend(content = Text(messages("editPage.heading")), isPageHeading = true, classes = "govuk-visually-hidden")),
-            html = innerHtml
-        ))
+        @inputHtml
 
         @button(Button(content = HtmlContent(messages("editPage.submitLabel")),
             name = Some("continue"),
@@ -71,7 +68,7 @@ select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
     }
 }
 
-@innerHtml = {
+@inputHtml = {
     @textInput(Input(value = editForm("organisation").value,
         label = Label(content = HtmlContent(messages("editPage.organisationLabel"))),
         formGroupClasses = "form-field-group", autocomplete = Some("organization"),

--- a/app/views/abp/non_uk_mode_edit.scala.html
+++ b/app/views/abp/non_uk_mode_edit.scala.html
@@ -21,7 +21,7 @@
 @import services.ForeignOfficeCountryService
 
 @this(form: FormWithCSRF, textarea: GovukTextarea, button: GovukButton, textInput: GovukInput, radios: GovukRadios,
-select: GovukSelect, page: page_template)
+select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
 @(id: String, journeyData: JourneyDataV2, editForm: Form[Edit], countries: Seq[(String, String)], isWelsh: Boolean, isUKMode: Boolean = false)(implicit request: Request[_], messages: Messages, appConfig: FrontendAppConfig)
 
 @errorPrefix = @{s"${messages("constants.error.prefix")} "}
@@ -59,90 +59,98 @@ select: GovukSelect, page: page_template)
     </h1>
 
     @form(routes.AbpAddressLookupController.handleEdit(id)) {
-        @textInput(Input(value = editForm("organisation").value,
-            label = Label(content = HtmlContent(messages("editPage.organisationLabel"))),
-            formGroupClasses = "form-field-group", autocomplete = Some("organization"),
-            name = editForm("organisation").name, id = editForm("organisation").name, classes = "govuk-input--width-20",
-            errorMessage = editForm("organisation").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-        @textInput(Input(value = editForm("line1").value,
-            label = Label(content = HtmlContent(messages("editPage.line1Label"))),
-            formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line1"),
-            name = editForm("line1").name, id = editForm("line1").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-            errorMessage = editForm("line1").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-        @textInput(Input(value = editForm("line2").value,
-            label = Label(content = HtmlContent(messages("editPage.line2Label"))),
-            formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line2"),
-            name = editForm("line2").name, id = editForm("line2").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-            errorMessage = editForm("line2").error.map(fe ⇒ ErrorMessage(content = HtmlContent("DUMMY")))))
-        @textInput(Input(value = editForm("line3").value,
-            label = Label(content = HtmlContent(messages("editPage.line3Label"))),
-            formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line3"),
-            name = editForm("line3").name, id = editForm("line3").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-            errorMessage = editForm("line3").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-        @textInput(Input(value = editForm("town").value,
-            label = Label(content = HtmlContent(messages("editPage.townLabel"))),
-            formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-level2"),
-            name = editForm("town").name, id = editForm("town").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-            errorMessage = editForm("town").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-        @textInput(Input(value = editForm("postcode").value,
-            label = Label(content = HtmlContent(messages("editPage.postcodeLabel"))),
-            formGroupClasses = "form-field-group", autocomplete = Some("postal-code"),
-            name = editForm("postcode").name, id = editForm("postcode").name, classes = "govuk-input--width-10",
-            errorMessage = editForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
 
-        @if(journeyData.countryCode.isDefined) {
-
-            @textInput(Input(value =
-                editForm("countryCode").value.flatMap(c => ForeignOfficeCountryService.find(code = c)).map(_.name),
-                attributes = Map("disabled" -> "disabled"),
-                label = Label(content = HtmlContent(messages("editPage.countryLabel"))),
-                formGroupClasses = "form-field-group", autocomplete = Some("country"),
-                name = "countryName", id = "countryName",
-                errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-
-            <input type="hidden" id="countryCode" name="countryCode" value="@editForm("countryCode").value" />
-        } else {
-
-            @select(components.Select(
-                id = "countryCode",
-                name = "countryCode",
-                label = Label(content = HtmlContent(messages("editPage.countryLabel"))),
-                errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message))),
-                items = Seq(SelectItem(value = Some(""), text = "Select a country")) ++ countries.map {
-                    case (k, v) ⇒ SelectItem(
-                        value = Some(k),
-                        text = v,
-                        selected = k == editForm("countryCode").value.getOrElse(""),
-                        attributes = Map("id" -> s"countryCode-$k"))
-                },
-                formGroupClasses = "form-field-group"
-            ))
-
-            <script src="@controllers.routes.Assets.at("accessible-autocomplete-2.0.2.min.js")" ></script>
-            <script>
-                    accessibleAutocomplete.enhanceSelectElement({
-                        selectElement: document.getElementById("countryCode"),
-                        name: 'countryCodeAutocomplete',
-                        defaultValue: '',
-                        @*
-                          TF-640: Had to override the onConfirm function to include custom validation for countries because null / undefined values are not handled by the Autocomplete form:
-                          https://github.com/alphagov/accessible-autocomplete/issues/260
-                          When this is fixed the custom validation / onConfirm bypass can be removed
-                        *@
-                        onConfirm: () => {
-                            const matchingOption = Array.from(document.querySelectorAll("#countryCode-select > option")).find(function (c) {
-                                return c.text === document.getElementById("countryCode").value;
-                            });
-                            const countryCode = matchingOption ? matchingOption.value : undefined;
-                            document.getElementById("countryCode-select").value = countryCode;
-                        }
-                    })
-            </script>
-        }
-
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(content = Text(messages("editPage.heading")), isPageHeading = true, classes = "govuk-visually-hidden")),
+            html = innerHtml
+        ))
 
         @button(Button(content = HtmlContent(messages("editPage.submitLabel")),
             name = Some("continue"),
             inputType = Some("submit"), attributes = Map("id" -> "continue")))
+    }
+}
+
+@innerHtml = {
+    @textInput(Input(value = editForm("organisation").value,
+        label = Label(content = HtmlContent(messages("editPage.organisationLabel"))),
+        formGroupClasses = "form-field-group", autocomplete = Some("organization"),
+        name = editForm("organisation").name, id = editForm("organisation").name, classes = "govuk-input--width-20",
+        errorMessage = editForm("organisation").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+    @textInput(Input(value = editForm("line1").value,
+        label = Label(content = HtmlContent(messages("editPage.line1Label"))),
+        formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line1"),
+        name = editForm("line1").name, id = editForm("line1").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
+        errorMessage = editForm("line1").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+    @textInput(Input(value = editForm("line2").value,
+        label = Label(content = HtmlContent(messages("editPage.line2Label"))),
+        formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line2"),
+        name = editForm("line2").name, id = editForm("line2").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
+        errorMessage = editForm("line2").error.map(fe ⇒ ErrorMessage(content = HtmlContent("DUMMY")))))
+    @textInput(Input(value = editForm("line3").value,
+        label = Label(content = HtmlContent(messages("editPage.line3Label"))),
+        formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line3"),
+        name = editForm("line3").name, id = editForm("line3").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
+        errorMessage = editForm("line3").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+    @textInput(Input(value = editForm("town").value,
+        label = Label(content = HtmlContent(messages("editPage.townLabel"))),
+        formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-level1"),
+        name = editForm("town").name, id = editForm("town").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
+        errorMessage = editForm("town").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+    @textInput(Input(value = editForm("postcode").value,
+        label = Label(content = HtmlContent(messages("editPage.postcodeLabel"))),
+        formGroupClasses = "form-field-group", autocomplete = Some("postal-code"),
+        name = editForm("postcode").name, id = editForm("postcode").name, classes = "govuk-input--width-10",
+        errorMessage = editForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+
+    @if(journeyData.countryCode.isDefined) {
+
+        @textInput(Input(value =
+            editForm("countryCode").value.flatMap(c => ForeignOfficeCountryService.find(code = c)).map(_.name),
+            attributes = Map("disabled" -> "disabled"),
+            label = Label(content = HtmlContent(messages("editPage.countryLabel"))),
+            formGroupClasses = "form-field-group", autocomplete = Some("country"),
+            name = "countryName", id = "countryName",
+            errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+
+        <input type="hidden" id="countryCode" name="countryCode" value="@editForm("countryCode").value" />
+    } else {
+
+        @select(components.Select(
+            id = "countryCode",
+            name = "countryCode",
+            label = Label(content = HtmlContent(messages("editPage.countryLabel"))),
+            errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message))),
+            items = Seq(SelectItem(value = Some(""), text = "Select a country")) ++ countries.map {
+                case (k, v) ⇒ SelectItem(
+                    value = Some(k),
+                    text = v,
+                    selected = k == editForm("countryCode").value.getOrElse(""),
+                    attributes = Map("id" -> s"countryCode-$k"))
+            },
+            formGroupClasses = "form-field-group"
+        ))
+
+        <script src="@controllers.routes.Assets.at("accessible-autocomplete-2.0.2.min.js")" ></script>
+        <script>
+                accessibleAutocomplete.enhanceSelectElement({
+                    selectElement: document.getElementById("countryCode"),
+                    name: 'countryCodeAutocomplete',
+                    defaultValue: '',
+                    showNoOptionsFound: false,
+                    @*
+                        TF-640: Had to override the onConfirm function to include custom validation for countries because null / undefined values are not handled by the Autocomplete form:
+                        https://github.com/alphagov/accessible-autocomplete/issues/260
+                        When this is fixed the custom validation / onConfirm bypass can be removed
+                    *@
+                    onConfirm: () => {
+                        const matchingOption = Array.from(document.querySelectorAll("#countryCode-select > option")).find(function (c) {
+                            return c.text === document.getElementById("countryCode").value;
+                        });
+                        const countryCode = matchingOption ? matchingOption.value : undefined;
+                        document.getElementById("countryCode-select").value = countryCode;
+                    }
+                })
+        </script>
     }
 }

--- a/app/views/abp/uk_mode_edit.scala.html
+++ b/app/views/abp/uk_mode_edit.scala.html
@@ -58,10 +58,7 @@ select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
 
     @form(routes.AbpAddressLookupController.handleEdit(id)) {
 
-        @govukFieldset(Fieldset(
-            legend = Some(Legend(content = Text(messages("editPage.heading")), isPageHeading = true, classes = "govuk-visually-hidden")),
-            html = innerHtml
-        ))
+        @inputHtml
 
         @button(Button(content = HtmlContent(messages("editPage.submitLabel")),
             name = Some("continue"),
@@ -69,7 +66,7 @@ select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
     }
 }
 
-@innerHtml = {
+@inputHtml = {
     @textInput(Input(value = editForm("organisation").value,
         label = Label(content = HtmlContent(messages("editPage.organisationLabel"))),
         formGroupClasses = "form-field-group", autocomplete = Some("organization"),

--- a/app/views/abp/uk_mode_edit.scala.html
+++ b/app/views/abp/uk_mode_edit.scala.html
@@ -19,7 +19,7 @@
 @import views.html.templates.page_template
 
 @this(form: FormWithCSRF, textarea: GovukTextarea, button: GovukButton, textInput: GovukInput, radios: GovukRadios,
-select: GovukSelect, page: page_template)
+select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
 @(id: String, journeyData: JourneyDataV2, editForm: Form[Edit], countries: Seq[(String, String)], isWelsh: Boolean, isUKMode: Boolean = true)(implicit request: Request[_], messages: Messages, appConfig: FrontendAppConfig)
 
 @errorPrefix = @{s"${messages("constants.error.prefix")} "}
@@ -57,39 +57,47 @@ select: GovukSelect, page: page_template)
     </h1>
 
     @form(routes.AbpAddressLookupController.handleEdit(id)) {
-            @textInput(Input(value = editForm("organisation").value,
-                label = Label(content = HtmlContent(messages("editPage.organisationLabel"))),
-                formGroupClasses = "form-field-group", autocomplete = Some("organization"),
-                name = editForm("organisation").name, id = editForm("organisation").name, classes = "govuk-input--width-20",
-                errorMessage = editForm("organisation").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-            @textInput(Input(value = editForm("line1").value,
-                label = Label(content = HtmlContent(messages("editPage.line1Label"))),
-                formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line1"),
-                name = editForm("line1").name, id = editForm("line1").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-                errorMessage = editForm("line1").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-            @textInput(Input(value = editForm("line2").value,
-                label = Label(content = HtmlContent(messages("editPage.line2Label"))),
-                formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line2"),
-                name = editForm("line2").name, id = editForm("line2").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-                errorMessage = editForm("line2").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-            @textInput(Input(value = editForm("line3").value,
-                label = Label(content = HtmlContent(messages("editPage.line3Label"))),
-                formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line3"),
-                name = editForm("line3").name, id = editForm("line3").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-                errorMessage = editForm("line3").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-            @textInput(Input(value = editForm("town").value,
-                label = Label(content = HtmlContent(messages("editPage.townLabel"))),
-                formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-level2"),
-                name = editForm("town").name, id = editForm("town").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-                errorMessage = editForm("town").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-            @textInput(Input(value = editForm("postcode").value,
-                label = Label(content = HtmlContent(messages("editPage.postcodeLabel.ukMode"))),
-                formGroupClasses = "form-field-group", autocomplete = Some("postal-code"),
-                name = editForm("postcode").name, id = editForm("postcode").name, classes = "govuk-input--width-10",
-                errorMessage = editForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
 
-            @button(Button(content = HtmlContent(messages("editPage.submitLabel")),
-                name = Some("continue"),
-                inputType = Some("submit"), attributes = Map("id" -> "continue")))
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(content = Text(messages("editPage.heading")), isPageHeading = true, classes = "govuk-visually-hidden")),
+            html = innerHtml
+        ))
+
+        @button(Button(content = HtmlContent(messages("editPage.submitLabel")),
+            name = Some("continue"),
+            inputType = Some("submit"), attributes = Map("id" -> "continue")))
     }
+}
+
+@innerHtml = {
+    @textInput(Input(value = editForm("organisation").value,
+        label = Label(content = HtmlContent(messages("editPage.organisationLabel"))),
+        formGroupClasses = "form-field-group", autocomplete = Some("organization"),
+        name = editForm("organisation").name, id = editForm("organisation").name, classes = "govuk-input--width-20",
+        errorMessage = editForm("organisation").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+    @textInput(Input(value = editForm("line1").value,
+        label = Label(content = HtmlContent(messages("editPage.line1Label"))),
+        formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line1"),
+        name = editForm("line1").name, id = editForm("line1").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
+        errorMessage = editForm("line1").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+    @textInput(Input(value = editForm("line2").value,
+        label = Label(content = HtmlContent(messages("editPage.line2Label"))),
+        formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line2"),
+        name = editForm("line2").name, id = editForm("line2").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
+        errorMessage = editForm("line2").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+    @textInput(Input(value = editForm("line3").value,
+        label = Label(content = HtmlContent(messages("editPage.line3Label"))),
+        formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line3"),
+        name = editForm("line3").name, id = editForm("line3").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
+        errorMessage = editForm("line3").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+    @textInput(Input(value = editForm("town").value,
+        label = Label(content = HtmlContent(messages("editPage.townLabel"))),
+        formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-level1"),
+        name = editForm("town").name, id = editForm("town").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
+        errorMessage = editForm("town").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+    @textInput(Input(value = editForm("postcode").value,
+        label = Label(content = HtmlContent(messages("editPage.postcodeLabel.ukMode"))),
+        formGroupClasses = "form-field-group", autocomplete = Some("postal-code"),
+        name = editForm("postcode").name, id = editForm("postcode").name, classes = "govuk-input--width-10",
+        errorMessage = editForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
 }

--- a/app/views/country_picker.scala.html
+++ b/app/views/country_picker.scala.html
@@ -81,6 +81,7 @@
                   selectElement: document.getElementById("countryCode"),
                   name: 'countryCodeAutocomplete',
                   defaultValue: '',
+                  showNoOptionsFound: false,
                   @*
                     TF-640: Had to override the onConfirm function to include custom validation for countries because null / undefined values are not handled by the Autocomplete form:
                     https://github.com/alphagov/accessible-autocomplete/issues/260

--- a/app/views/international/edit.scala.html
+++ b/app/views/international/edit.scala.html
@@ -21,7 +21,7 @@
 @import services.ForeignOfficeCountryService
 
 @this(form: FormWithCSRF, textarea: GovukTextarea, button: GovukButton, textInput: GovukInput, radios: GovukRadios,
-select: GovukSelect, page: page_template)
+select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
 @(id: String, journeyData: JourneyDataV2, editForm: Form[Edit], countries: Seq[(String, String)], isWelsh: Boolean, isUKMode: Boolean = false)(implicit request: Request[_], messages: Messages, appConfig: FrontendAppConfig)
 
 @resolvedConf = @{
@@ -66,90 +66,98 @@ select: GovukSelect, page: page_template)
     </h1>
 
     @form(routes.InternationalAddressLookupController.handleEdit(id)) {
-        @textInput(Input(value = editForm("organisation").value,
-            label = Label(content = HtmlContent(internationalMessage("editPage.organisationLabel"))),
-            formGroupClasses = "form-field-group", autocomplete = Some("organization"),
-            name = editForm("organisation").name, id = editForm("organisation").name, classes = "govuk-input--width-20",
-            errorMessage = editForm("organisation").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-        @textInput(Input(value = editForm("line1").value,
-            label = Label(content = HtmlContent(internationalMessage("editPage.line1Label"))),
-            formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line1"),
-            name = editForm("line1").name, id = editForm("line1").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-            errorMessage = editForm("line1").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-        @textInput(Input(value = editForm("line2").value,
-            label = Label(content = HtmlContent(internationalMessage("editPage.line2Label"))),
-            formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line2"),
-            name = editForm("line2").name, id = editForm("line2").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-            errorMessage = editForm("line2").error.map(fe ⇒ ErrorMessage(content = HtmlContent("DUMMY")))))
-        @textInput(Input(value = editForm("line3").value,
-            label = Label(content = HtmlContent(internationalMessage("editPage.line3Label"))),
-            formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line3"),
-            name = editForm("line3").name, id = editForm("line3").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-            errorMessage = editForm("line3").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-        @textInput(Input(value = editForm("town").value,
-            label = Label(content = HtmlContent(internationalMessage("editPage.townLabel"))),
-            formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-level2"),
-            name = editForm("town").name, id = editForm("town").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-            errorMessage = editForm("town").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-        @textInput(Input(value = editForm("postcode").value,
-            label = Label(content = HtmlContent(internationalMessage("editPage.postcodeLabel"))),
-            formGroupClasses = "form-field-group", autocomplete = Some("postal-code"),
-            name = editForm("postcode").name, id = editForm("postcode").name, classes = "govuk-input--width-10",
-            errorMessage = editForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-
-        @if(journeyData.countryCode.isDefined) {
-
-            @textInput(Input(value =
-                editForm("countryCode").value.flatMap(c => ForeignOfficeCountryService.find(code = c)).map(_.name),
-                attributes = Map("disabled" -> "disabled"),
-                label = Label(content = HtmlContent(internationalMessage("editPage.countryLabel"))),
-                formGroupClasses = "form-field-group", autocomplete = Some("country"),
-                name = "countryName", id = "countryName",
-                errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
-
-            <input type="hidden" id="countryCode" name="countryCode" value="@editForm("countryCode").value" />
-        } else {
-
-            @select(components.Select(
-                id = "countryCode",
-                name = "countryCode",
-                label = Label(content = HtmlContent(internationalMessage("editPage.countryLabel"))),
-                errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message))),
-                items = Seq(SelectItem(value = Some(""), text = "Select a country")) ++ countries.map {
-                    case (k, v) ⇒ SelectItem(
-                        value = Some(k),
-                        text = v,
-                        selected = k == editForm("countryCode").value.getOrElse(""),
-                        attributes = Map("id" -> s"countryCode-$k"))
-                },
-                formGroupClasses = "form-field-group"
-            ))
-
-            <script src="@controllers.routes.Assets.at("accessible-autocomplete-2.0.2.min.js")" ></script>
-            <script>
-                    accessibleAutocomplete.enhanceSelectElement({
-                        selectElement: document.getElementById("countryCode"),
-                        name: 'countryCodeAutocomplete',
-                        defaultValue: '',
-                        @*
-                          TF-640: Had to override the onConfirm function to include custom validation for countries because null / undefined values are not handled by the Autocomplete form:
-                          https://github.com/alphagov/accessible-autocomplete/issues/260
-                          When this is fixed the custom validation / onConfirm bypass can be removed
-                        *@
-                        onConfirm: () => {
-                            const matchingOption = Array.from(document.querySelectorAll("#countryCode-select > option")).find(function (c) {
-                                return c.text === document.getElementById("countryCode").value;
-                            });
-                            const countryCode = matchingOption ? matchingOption.value : undefined;
-                            document.getElementById("countryCode-select").value = countryCode;
-                        }
-                    })
-            </script>
-        }
-
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(content = Text(internationalMessage("editPage.heading")), isPageHeading = false, classes = "govuk-visually-hidden")),
+            html = innerHtml
+        ))
 
         @button(Button(content = HtmlContent(internationalMessage("editPage.submitLabel")),
             name = Some("continue"),
             inputType = Some("submit"), attributes = Map("id" -> "continue")))
     }
+}
+
+@innerHtml = {
+    @textInput(Input(value = editForm("organisation").value,
+        label = Label(content = HtmlContent(internationalMessage("editPage.organisationLabel"))),
+        formGroupClasses = "form-field-group", autocomplete = Some("organization"),
+        name = editForm("organisation").name, id = editForm("organisation").name, classes = "govuk-input--width-20",
+        errorMessage = editForm("organisation").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+    @textInput(Input(value = editForm("line1").value,
+        label = Label(content = HtmlContent(internationalMessage("editPage.line1Label"))),
+        formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line1"),
+        name = editForm("line1").name, id = editForm("line1").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
+        errorMessage = editForm("line1").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+    @textInput(Input(value = editForm("line2").value,
+        label = Label(content = HtmlContent(internationalMessage("editPage.line2Label"))),
+        formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line2"),
+        name = editForm("line2").name, id = editForm("line2").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
+        errorMessage = editForm("line2").error.map(fe ⇒ ErrorMessage(content = HtmlContent("DUMMY")))))
+    @textInput(Input(value = editForm("line3").value,
+        label = Label(content = HtmlContent(internationalMessage("editPage.line3Label"))),
+        formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line3"),
+        name = editForm("line3").name, id = editForm("line3").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
+        errorMessage = editForm("line3").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+    @textInput(Input(value = editForm("town").value,
+        label = Label(content = HtmlContent(internationalMessage("editPage.townLabel"))),
+        formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-level1"),
+        name = editForm("town").name, id = editForm("town").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
+        errorMessage = editForm("town").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+    @textInput(Input(value = editForm("postcode").value,
+        label = Label(content = HtmlContent(internationalMessage("editPage.postcodeLabel"))),
+        formGroupClasses = "form-field-group", autocomplete = Some("postal-code"),
+        name = editForm("postcode").name, id = editForm("postcode").name, classes = "govuk-input--width-10",
+        errorMessage = editForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+
+    @if(journeyData.countryCode.isDefined) {
+
+        @textInput(Input(value =
+            editForm("countryCode").value.flatMap(c => ForeignOfficeCountryService.find(code = c)).map(_.name),
+            attributes = Map("disabled" -> "disabled"),
+            label = Label(content = HtmlContent(internationalMessage("editPage.countryLabel"))),
+            formGroupClasses = "form-field-group", autocomplete = Some("country"),
+            name = "countryName", id = "countryName",
+            errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+
+        <input type="hidden" id="countryCode" name="countryCode" value="@editForm("countryCode").value" />
+    } else {
+
+    @select(components.Select(
+        id = "countryCode",
+        name = "countryCode",
+        label = Label(content = HtmlContent(internationalMessage("editPage.countryLabel"))),
+        errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message))),
+        items = Seq(SelectItem(value = Some(""), text = "Select a country")) ++ countries.map {
+            case (k, v) ⇒ SelectItem(
+                value = Some(k),
+                text = v,
+                selected = k == editForm("countryCode").value.getOrElse(""),
+                attributes = Map("id" -> s"countryCode-$k"))
+        },
+        formGroupClasses = "form-field-group"
+    ))
+
+
+    <script src="@controllers.routes.Assets.at("accessible-autocomplete-2.0.2.min.js")" ></script>
+    <script>
+            accessibleAutocomplete.enhanceSelectElement({
+                selectElement: document.getElementById("countryCode"),
+                name: 'countryCodeAutocomplete',
+                defaultValue: '',
+                showNoOptionsFound: false,
+                @*
+                  TF-640: Had to override the onConfirm function to include custom validation for countries because null / undefined values are not handled by the Autocomplete form:
+                  https://github.com/alphagov/accessible-autocomplete/issues/260
+                  When this is fixed the custom validation / onConfirm bypass can be removed
+                *@
+                onConfirm: () => {
+                    const matchingOption = Array.from(document.querySelectorAll("#countryCode-select > option")).find(function (c) {
+                        return c.text === document.getElementById("countryCode").value;
+                    });
+                    const countryCode = matchingOption ? matchingOption.value : undefined;
+                    document.getElementById("countryCode-select").value = countryCode;
+                }
+            })
+    </script>
+  }
 }

--- a/app/views/international/edit.scala.html
+++ b/app/views/international/edit.scala.html
@@ -66,10 +66,7 @@ select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
     </h1>
 
     @form(routes.InternationalAddressLookupController.handleEdit(id)) {
-        @govukFieldset(Fieldset(
-            legend = Some(Legend(content = Text(internationalMessage("editPage.heading")), isPageHeading = false, classes = "govuk-visually-hidden")),
-            html = innerHtml
-        ))
+        @inputHtml
 
         @button(Button(content = HtmlContent(internationalMessage("editPage.submitLabel")),
             name = Some("continue"),
@@ -77,7 +74,7 @@ select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
     }
 }
 
-@innerHtml = {
+@inputHtml = {
     @textInput(Input(value = editForm("organisation").value,
         label = Label(content = HtmlContent(internationalMessage("editPage.organisationLabel"))),
         formGroupClasses = "form-field-group", autocomplete = Some("organization"),

--- a/app/views/international/no_results.scala.html
+++ b/app/views/international/no_results.scala.html
@@ -32,7 +32,7 @@
         messages(key)
 }
 
-@page(internationalMessage("constants.noResultsPageTitle"), None, journeyData) {
+@page(s"${internationalMessage("constants.noResultsPageHeading")} $filter", None, journeyData) {
 
     <h1 class="@{resolvedConf.options.pageHeadingStyle}" id="pageHeading">
         @{s"${internationalMessage("constants.noResultsPageHeading")} $filter"}

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,10 @@ lazy val root = Project(appName, file("."))
   .settings(
     libraryDependencies ++= AppDependencies.appDependencies,
     retrieveManaged := true,
-    update / evictionWarningOptions := EvictionWarningOptions.default.withWarnScalaVersionEviction(false)
+    update / evictionWarningOptions := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
+    PlayKeys.playDefaultPort := 9028,
   )
+  
   .configs(IntegrationTest)
   .settings(integrationTestSettings(): _*)
   .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)

--- a/conf/messages
+++ b/conf/messages
@@ -70,7 +70,7 @@ constants.errorText = There is a problem
 constants.noResults = We could not find a match with
 constants.differentSearch = Try a different name or number
 
-constants.noResultsPageTitle = We cannot find any addresses
+constants.noResultsPageTitle = We cannot find any addresses for
 constants.noResultsPageHeading = We cannot find any addresses for
 constants.noResultsPageEnterManually = Enter the address manually
 constants.noResultsPageDifferentPostcode = Try a different postcode
@@ -173,4 +173,4 @@ international.confirmPage.changeLinkText = Edit address
 international.confirmPage.confirmChangeText = By confirming this change, you agree that the information you have given is complete and correct.
 international.confirmPage.searchAgainLinkText = Search again
 
-phaseBannerHtml = This is a new service – your <a href='$link' class='govuk-link'>feedback</a> will help us to improve it.
+phaseBannerHtml = This is a new service – your <a href="$link" class="govuk-link">feedback</a> will help us to improve it.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -173,4 +173,4 @@ international.confirmPage.changeLinkText = Golygwch gyfeiriad
 international.confirmPage.confirmChangeText = Drwy gadarnhau’r newid hwn, rydych yn cytuno bod yr wybodaeth a roesoch yn gyflawn ac yn gywir.
 international.confirmPage.searchAgainLinkText = Chwilio eto
 
-phaseBannerHtml = Mae hwn yn wasanaeth newydd – bydd eich <a href='$link' class='govuk-link'>adborth</a> yn ein helpu i’w wella
+phaseBannerHtml = Mae hwn yn wasanaeth newydd – bydd eich <a href="$link" class="govuk-link">adborth</a> yn ein helpu i’w wella

--- a/it/controllers/abp/EditPageISpec.scala
+++ b/it/controllers/abp/EditPageISpec.scala
@@ -27,8 +27,8 @@ class EditPageISpec extends IntegrationSpecBase {
         val document = Jsoup.parse(res.body)
         //testElementExists(res, EditPage.nonUkEditId)
         document.title() shouldBe messages("editPage.title")
-        document.getElementById("pageHeading").text() shouldBe messages("editPage.heading")
-        document.getElementById("pageHeading").classNames() should contain("govuk-heading-xl")
+        document.h1.first.text() shouldBe messages("editPage.heading")
+        document.h1.first.classNames() should contain("govuk-heading-xl")
         document.getElementById("continue").text() shouldBe "Continue"
 
         document.getElementById("line1").`val` shouldBe "1 High Street"
@@ -67,7 +67,7 @@ class EditPageISpec extends IntegrationSpecBase {
         val document = Jsoup.parse(res.body)
         //testElementExists(res, EditPage.nonUkEditId)
         document.title() shouldBe messages(Lang("cy"), "editPage.title")
-        document.getElementById("pageHeading").text() shouldBe messages(Lang("cy"), "editPage.heading")
+        document.h1.first.text() shouldBe messages(Lang("cy"), "editPage.heading")
         document.getElementById("continue").text() shouldBe "Yn eich blaen"
 
         document.getElementById("line1").`val` shouldBe "1 High Street"
@@ -114,7 +114,7 @@ class EditPageISpec extends IntegrationSpecBase {
 
           res.status shouldBe OK
           val document = Jsoup.parse(res.body)
-          document.getElementById("pageHeading").classNames() should contain("govuk-heading-l")
+          document.h1.first.classNames() should contain("govuk-heading-l")
         }
 
         "uk Mode is true" in {
@@ -130,7 +130,7 @@ class EditPageISpec extends IntegrationSpecBase {
 
           res.status shouldBe OK
           val document = Jsoup.parse(res.body)
-          document.getElementById("pageHeading").classNames() should contain("govuk-heading-l")
+          document.h1.first.classNames() should contain("govuk-heading-l")
         }
       }
 
@@ -204,7 +204,7 @@ class EditPageISpec extends IntegrationSpecBase {
         val document = Jsoup.parse(res.body)
 //        //testElementExists(res, EditPage.nonUkEditId)
         document.title() shouldBe messages(Lang("cy"), "editPage.title")
-        document.getElementById("pageHeading").text() shouldBe messages(Lang("cy"), "editPage.heading")
+        document.h1.first.text() shouldBe messages(Lang("cy"), "editPage.heading")
         document.getElementById("continue").text() shouldBe "Yn eich blaen"
         Option(document.getElementById("countryCode")).isDefined shouldBe true
 
@@ -239,7 +239,7 @@ class EditPageISpec extends IntegrationSpecBase {
         val document = Jsoup.parse(res.body)
 //        testElementExists(res, EditPage.nonUkEditId)
         document.title() shouldBe "edit-title"
-        document.getElementById("pageHeading").text() shouldBe "edit-heading"
+        document.h1.first.text() shouldBe "edit-heading"
         document.getElementById("continue").text() shouldBe "edit-submitLabel"
 
         document.getElementById("line1").`val` shouldBe "1 High Street"
@@ -272,7 +272,7 @@ class EditPageISpec extends IntegrationSpecBase {
         val document = Jsoup.parse(res.body)
 //        testElementExists(res, EditPage.nonUkEditId)
         document.title() shouldBe "edit-title"
-        document.getElementById("pageHeading").text() shouldBe "edit-heading"
+        document.h1.first.text() shouldBe "edit-heading"
         document.getElementById("continue").text() shouldBe "edit-submitLabel"
         Option(document.getElementById("countryCode")).isDefined shouldBe true
 
@@ -325,7 +325,7 @@ class EditPageISpec extends IntegrationSpecBase {
         val document = Jsoup.parse(res.body)
         //testElementExists(res, EditPage.nonUkEditId)
         document.title() shouldBe "edit-title welsh"
-        document.getElementById("pageHeading").text() shouldBe "edit-heading welsh"
+        document.h1.first.text() shouldBe "edit-heading welsh"
         document.getElementById("continue").text() shouldBe "edit-submitLabel welsh"
 
         document.getElementById("line1").`val` shouldBe "1 High Street"
@@ -357,7 +357,7 @@ class EditPageISpec extends IntegrationSpecBase {
         val document = Jsoup.parse(res.body)
         //testElementExists(res, EditPage.nonUkEditId)
         document.title() shouldBe "edit-title"
-        document.getElementById("pageHeading").text() shouldBe "edit-heading"
+        document.h1.first.text() shouldBe "edit-heading"
         document.getElementById("continue").text() shouldBe "edit-submitLabel"
         Option(document.getElementById("countryCode")).isDefined shouldBe true
 
@@ -410,7 +410,7 @@ class EditPageISpec extends IntegrationSpecBase {
         val document = Jsoup.parse(res.body)
         //testElementExists(res, EditPage.nonUkEditId)
         document.title() shouldBe "edit-title welsh"
-        document.getElementById("pageHeading").text() shouldBe "edit-heading welsh"
+        document.h1.first.text() shouldBe "edit-heading welsh"
         document.getElementById("continue").text() shouldBe "edit-submitLabel welsh"
 
         document.getElementById("line1").`val` shouldBe "1 High Street"
@@ -470,7 +470,7 @@ class EditPageISpec extends IntegrationSpecBase {
       val document = Jsoup.parse(res.body)
 
       document.title shouldBe "Gwall: Nodwch eich cyfeiriad"
-      document.h1.text shouldBe "Nodwch eich cyfeiriad"
+      document.h1.first.text() shouldBe "Nodwch eich cyfeiriad"
       document.submitButton.text shouldBe "Yn eich blaen"
       Option(document.getElementById("countryCode")).isDefined shouldBe true
 
@@ -567,7 +567,7 @@ class EditPageISpec extends IntegrationSpecBase {
       //testElementExists(res, EditPage.ukEditId)
 
       document.title shouldBe s"Error: ${messages("editPage.title")}"
-      document.h1.text shouldBe messages("editPage.heading")
+      document.h1.first.text() shouldBe messages("editPage.heading")
       document.submitButton.text shouldBe "Continue"
       testElementDoesntExist(res,"countryCode")
 
@@ -607,7 +607,7 @@ class EditPageISpec extends IntegrationSpecBase {
       val document = Jsoup.parse(res.body)
 
       document.title shouldBe s"Gwall: ${messages(Lang("cy"), "editPage.title")}"
-      document.h1.text shouldBe messages(Lang("cy"), "editPage.title")
+      document.h1.first.text() shouldBe messages(Lang("cy"), "editPage.title")
       document.submitButton.text shouldBe "Yn eich blaen"
       testElementDoesntExist(res,"countryCode")
 

--- a/it/controllers/abp/NoResultsFoundPageISpec.scala
+++ b/it/controllers/abp/NoResultsFoundPageISpec.scala
@@ -13,7 +13,7 @@ import play.api.libs.json.Json
 class NoResultsFoundPageISpec extends IntegrationSpecBase {
 
   object EnglishContent {
-    val title = "We cannot find any addresses"
+    def title(postcode: String) = s"We cannot find any addresses for $postcode"
 
     def heading(postcode: String) = s"We cannot find any addresses for $postcode"
 
@@ -22,7 +22,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
   }
 
   object WelshContent {
-    val title = "Ni allwn ddod o hyd i unrhyw gyfeiriadau"
+    def title(postcode: String) = s"Ni allwn ddod o hyd i unrhyw gyfeiriadau ar gyfer $postcode"
 
     def heading(postcode: String) = s"Ni allwn ddod o hyd i unrhyw gyfeiriadau ar gyfer $postcode"
 
@@ -47,7 +47,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
 
         testCustomPartsOfGovWrapperElementsForDefaultConfig(fResponse)
 
-        doc.title shouldBe EnglishContent.title
+        doc.title shouldBe EnglishContent.title(testPostCode)
         doc.h1.text() shouldBe EnglishContent.heading(testPostCode)
 
         doc.select("a[class=govuk-back-link]") should have(
@@ -81,7 +81,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
 
         testCustomPartsOfGovWrapperElementsForFullConfigAllTrue(fResponse, "NAV_TITLE")
 
-        doc.title shouldBe EnglishContent.title + " - NAV_TITLE - GOV.UK"
+        doc.title shouldBe EnglishContent.title(testPostCode) + " - NAV_TITLE - GOV.UK"
         doc.h1.text() shouldBe EnglishContent.heading(testPostCode)
 
         doc.select("a[class=govuk-back-link]") should have(
@@ -117,7 +117,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
 
         testCustomPartsOfGovWrapperElementsForFullConfigWithAllTopConfigAsNoneAndAllBooleansFalse(fResponse)
 
-        doc.title shouldBe EnglishContent.title
+        doc.title shouldBe EnglishContent.title(testPostCode)
         doc.h1.text() shouldBe EnglishContent.heading(testPostCode)
 
         doc.select("a[class=govuk-back-link]") should have(
@@ -153,7 +153,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
 
         testCustomPartsOfGovWrapperElementsForFullConfigWithAllTopConfigAsNoneAndAllBooleansFalse(fResponse)
 
-        doc.title shouldBe WelshContent.title
+        doc.title shouldBe WelshContent.title(testPostCode)
         doc.h1.text() shouldBe WelshContent.heading(testPostCode)
 
         doc.select("a[class=govuk-back-link]") should have(
@@ -198,7 +198,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
 
         res.status shouldBe OK
 
-        doc.title shouldBe EnglishContent.title
+        doc.title shouldBe EnglishContent.title(testPostCode)
         doc.h1.text() shouldBe EnglishContent.heading(testPostCode)
 
         doc.select("a[class=govuk-back-link]") should not have (

--- a/it/controllers/abp/TooManyResultsISpec.scala
+++ b/it/controllers/abp/TooManyResultsISpec.scala
@@ -45,7 +45,7 @@ class TooManyResultsISpec extends IntegrationSpecBase with PageContentHelper {
   }
 
   object otherPageMessages {
-    val noResultsPageTitle = "We cannot find any addresses"
+    val noResultsPageTitle = "We cannot find any addresses for"
   }
 
   //  val EnglishConstantsUkMode = EnglishConstants(true)
@@ -250,7 +250,7 @@ class TooManyResultsISpec extends IntegrationSpecBase with PageContentHelper {
 
         val doc = getDocFromResponse(res)
 
-        doc.title shouldBe otherPageMessages.noResultsPageTitle
+        doc.title shouldBe s"${otherPageMessages.noResultsPageTitle} AB11 1AB"
       }
     }
   }

--- a/it/controllers/international/EditPageISpec.scala
+++ b/it/controllers/international/EditPageISpec.scala
@@ -26,7 +26,7 @@ class EditPageISpec extends IntegrationSpecBase {
         val document = Jsoup.parse(res.body)
         //testElementExists(res, EditPage.nonUkEditId)
         document.title() shouldBe messages("international.editPage.title")
-        document.getElementById("pageHeading").text() shouldBe messages("international.editPage.heading")
+        document.h1.first.text() shouldBe messages("international.editPage.heading")
         document.getElementById("pageHeading").classNames() should contain("govuk-heading-xl")
         document.getElementById("continue").text() shouldBe "Continue"
 
@@ -66,7 +66,7 @@ class EditPageISpec extends IntegrationSpecBase {
         val document = Jsoup.parse(res.body)
         //testElementExists(res, EditPage.nonUkEditId)
         document.title() shouldBe messages(Lang("cy"), "international.editPage.title")
-        document.getElementById("pageHeading").text() shouldBe messages(Lang("cy"), "international.editPage.heading")
+        document.h1.first.text() shouldBe messages(Lang("cy"), "international.editPage.heading")
         document.getElementById("continue").text() shouldBe "Yn eich blaen"
 
         document.getElementById("line1").`val` shouldBe "1 High Street"
@@ -138,7 +138,7 @@ class EditPageISpec extends IntegrationSpecBase {
         val document = Jsoup.parse(res.body)
         //        //testElementExists(res, EditPage.nonUkEditId)
         document.title() shouldBe messages(Lang("cy"), "international.editPage.title")
-        document.getElementById("pageHeading").text() shouldBe  messages(Lang("cy"), "international.editPage.heading")
+        document.h1.first.text() shouldBe  messages(Lang("cy"), "international.editPage.heading")
         document.getElementById("continue").text() shouldBe "Yn eich blaen"
         Option(document.getElementById("countryName")).isDefined shouldBe true
 
@@ -172,7 +172,7 @@ class EditPageISpec extends IntegrationSpecBase {
         res.status shouldBe OK
         val document = Jsoup.parse(res.body)
         document.title() shouldBe "international-edit-title"
-        document.getElementById("pageHeading").text() shouldBe "international-edit-heading"
+        document.h1.first.text() shouldBe "international-edit-heading"
         document.getElementById("continue").text() shouldBe "international-edit-submitLabel"
 
         document.getElementById("line1").`val` shouldBe "1 High Street"
@@ -204,7 +204,7 @@ class EditPageISpec extends IntegrationSpecBase {
         res.status shouldBe OK
         val document = Jsoup.parse(res.body)
         document.title() shouldBe "international-edit-title"
-        document.getElementById("pageHeading").text() shouldBe "international-edit-heading"
+        document.h1.first.text() shouldBe "international-edit-heading"
         document.getElementById("continue").text() shouldBe "international-edit-submitLabel"
         Option(document.getElementById("countryName")).isDefined shouldBe true
 
@@ -258,7 +258,7 @@ class EditPageISpec extends IntegrationSpecBase {
         val document = Jsoup.parse(res.body)
         //testElementExists(res, EditPage.nonUkEditId)
         document.title() shouldBe "edit-title welsh"
-        document.getElementById("pageHeading").text() shouldBe "edit-heading welsh"
+        document.h1.first.text() shouldBe "edit-heading welsh"
         document.getElementById("continue").text() shouldBe "edit-submitLabel welsh"
 
         document.getElementById("line1").`val` shouldBe "1 High Street"

--- a/it/controllers/international/NoResultsFoundPageISpec.scala
+++ b/it/controllers/international/NoResultsFoundPageISpec.scala
@@ -13,7 +13,7 @@ import play.api.libs.json.Json
 class NoResultsFoundPageISpec extends IntegrationSpecBase {
 
   object EnglishContent {
-    val title = "We cannot find any addresses"
+    def title(postcode: String) = s"We cannot find any addresses for $postcode"
 
     def heading(postcode: String) = s"We cannot find any addresses for $postcode"
 
@@ -22,7 +22,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
   }
 
   object WelshContent {
-    val title = "Ni allwn ddod o hyd i unrhyw gyfeiriadau"
+    def title(postcode: String) = s"Ni allwn ddod o hyd i unrhyw gyfeiriadau ar gyfer $postcode"
 
     def heading(postcode: String) = s"Ni allwn ddod o hyd i unrhyw gyfeiriadau ar gyfer $postcode"
 
@@ -47,7 +47,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
 
         testCustomPartsOfGovWrapperElementsForDefaultConfig(fResponse)
 
-        doc.title shouldBe EnglishContent.title
+        doc.title shouldBe EnglishContent.title(testFilterValue)
         doc.h1.text() shouldBe EnglishContent.heading(testFilterValue)
 
         doc.select("a[class=govuk-back-link]") should have(
@@ -79,7 +79,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
 
         testCustomPartsOfGovWrapperElementsForFullConfigAllTrue(fResponse, "NAV_TITLE")
 
-        doc.title shouldBe EnglishContent.title + " - NAV_TITLE - GOV.UK"
+        doc.title shouldBe EnglishContent.title(testFilterValue) + " - NAV_TITLE - GOV.UK"
         doc.h1.text() shouldBe EnglishContent.heading(testFilterValue)
 
         doc.select("a[class=govuk-back-link]") should have(
@@ -113,7 +113,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
 
         testCustomPartsOfGovWrapperElementsForFullConfigWithAllTopConfigAsNoneAndAllBooleansFalse(fResponse)
 
-        doc.title shouldBe EnglishContent.title
+        doc.title shouldBe EnglishContent.title(testFilterValue)
         doc.h1.text() shouldBe EnglishContent.heading(testFilterValue)
 
         doc.select("a[class=govuk-back-link]") should have(
@@ -147,7 +147,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
 
         testCustomPartsOfGovWrapperElementsForFullConfigWithAllTopConfigAsNoneAndAllBooleansFalse(fResponse)
 
-        doc.title shouldBe WelshContent.title
+        doc.title shouldBe WelshContent.title(testFilterValue)
         doc.h1.text() shouldBe WelshContent.heading(testFilterValue)
 
         doc.select("a[class=govuk-back-link]") should have(
@@ -191,7 +191,7 @@ class NoResultsFoundPageISpec extends IntegrationSpecBase {
 
         res.status shouldBe OK
 
-        doc.title shouldBe EnglishContent.title
+        doc.title shouldBe EnglishContent.title(testFilterValue)
         doc.h1.text() shouldBe EnglishContent.heading(testFilterValue)
 
         doc.select("a[class=govuk-back-link]") should not have (

--- a/it/controllers/international/TooManyResultsISpec.scala
+++ b/it/controllers/international/TooManyResultsISpec.scala
@@ -45,7 +45,7 @@ class TooManyResultsISpec extends IntegrationSpecBase with PageContentHelper {
   }
 
   object otherPageMessages {
-    val noResultsPageTitle = "We cannot find any addresses"
+    val noResultsPageTitle = "We cannot find any addresses for"
   }
 
   //  val EnglishConstantsUkMode = EnglishConstants(true)
@@ -191,7 +191,7 @@ class TooManyResultsISpec extends IntegrationSpecBase with PageContentHelper {
 
         val doc = getDocFromResponse(res)
 
-        doc.title shouldBe otherPageMessages.noResultsPageTitle
+        doc.title shouldBe s"${otherPageMessages.noResultsPageTitle} $testFilterValue"
       }
     }
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,4 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
 
-addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.5.1")
+addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")

--- a/test/views/NonUKModeEditViewSpec.scala
+++ b/test/views/NonUKModeEditViewSpec.scala
@@ -88,5 +88,19 @@ class NonUKModeEditViewSpec extends ViewSpec {
         option("countryCode-AL", "Albanian")
       )
     }
+
+    "the town field should have autocomplete attribute of address-level1" in {
+      val testPage = non_uk_mode_edit(
+        id = testId,
+        journeyData = fullV2JourneyDataNonUkMode.copy(config = configWithoutLabels),
+        editForm = nonUkEditForm(),
+        countries = Seq("FR" -> "France", "AL" -> "Albanian"),
+        isWelsh = false
+      )
+      val doc: Document = Jsoup.parse(testPage.body)
+
+      doc.getElementById("town").attr("autocomplete") shouldBe "address-level1"
+    
+    }
   }
 }

--- a/test/views/UKModeEditViewSpec.scala
+++ b/test/views/UKModeEditViewSpec.scala
@@ -17,23 +17,70 @@
 package views
 
 import config.FrontendAppConfig
-import play.api.i18n.MessagesApi
+import model._
+import forms.ALFForms._
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.i18n.{Lang, MessagesApi}
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import views.html.abp.non_uk_mode_edit
+import utils.TestConstants._
+import views.html.abp.{lookup, select, uk_mode_edit}
 
 class UKModeEditViewSpec extends ViewSpec {
-  val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
-  implicit val testRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
-  implicit val frontendAppConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
 
-  val non_uk_mode_edit: non_uk_mode_edit = app.injector.instanceOf[non_uk_mode_edit]
+  object defaultContent {
+    val title = "Enter address - navTitle - GOV.UK"
+    val heading = "Enter address"
+    val addressLine1 = "Address line 1"
+    val addressLine2 = "Address line 2 (optional)"
+    val addressLine3 = "Address line 3 (optional)"
+    val townCity = "Town/city"
+    val postcodeInternational = "Postcode (optional)"
+    val country = "Country"
+    val continue = "Continue"
+  }
+
+  object configuredContent {
+    val title = "editTitle - navTitle - GOV.UK"
+    val heading = "editHeading"
+    val addressLine1 = "editLine1"
+    val addressLine2 = "editLine2"
+    val addressLine3 = "editLine3"
+    val townCity = "editLine4"
+    val postcodeInternational = "editPostcode"
+    val country = "editCountry"
+    val continue = "editSubmit"
+  }
+
+  implicit val testRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+  val messagesApi = app.injector.instanceOf[MessagesApi]
+  implicit val frontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
+  val lookup = app.injector.instanceOf[lookup]
+  val select = app.injector.instanceOf[select]
+  val uk_mode_edit = app.injector.instanceOf[uk_mode_edit]
+
+  val configWithoutLabels = fullV2JourneyConfig.copy(
+    options = fullV2JourneyOptions.copy(ukMode = Some(false)),
+    labels = Some(JourneyLabels(
+      en = Some(fullV2LanguageLabelsEn.copy(editPageLabels = None))
+    )))
 
   "UK Mode Page" should {
-    //implicit val lang: Lang = Lang("en")
+    implicit val lang: Lang = Lang("en")
 
-    //TODO: TESTS_REQUIRED
-    //would be nice to have some tests around the rendering of errors perhaps
-    //do we need to test for the back button?
+    "the town field should have autocomplete attribute of address-level1" in {
+      val testPage = uk_mode_edit(
+        id = testId,
+        journeyData = fullV2JourneyDataNonUkMode.copy(config = configWithoutLabels),
+        editForm = ukEditForm(),
+        countries = Seq("FR" -> "France", "AL" -> "Albanian"),
+        isWelsh = false
+      )
+      val doc: Document = Jsoup.parse(testPage.body)
+
+      doc.getElementById("town").attr("autocomplete") shouldBe "address-level1"
+    
+    }
   }
 }


### PR DESCRIPTION
- Fixed error on phase banner whereby HTML was being generated without attribute values wrapped in quotes (see changes in the messages files)
- Fixed the autocomplete attribute for town/city to be address-level1
- Changed the page title for "We cannot find any addresses" to match the heading and be "We cannot find any address for {POSTCODE}" or for international whatever filter was applied instead of postcode. The welsh titles also reflect the heading.
- The backlink is now hidden when the user has javascript disabled. The backlink relies on javascript so is unusable if the user has it disabled and so it should be hidden.
- updated the sassify version as tests wouldn't run on M1 macs.

- the changes to move the input html to a variable was done as I was going to wrap the input fields in a fieldset and have the header as the legend following another issue raised by accessibility. The issue with doing this is that as you allow services to set their own header classes, any services who have set the header classes to "govuk-heading-l” will find a breaking change as for fieldsets it would need to be “govuk-fieldset__legend--xl”. To add a fieldset, you just need to use the govukFieldset html, passing in the html variable.