### PR TITLE
DDS2-2144 - Ensure that visually hidden error prefixes display Welsh correctly

### DIFF
--- a/app/views/abp/lookup.scala.html
+++ b/app/views/abp/lookup.scala.html
@@ -68,7 +68,7 @@
           autocomplete = Some("postal-code"),
           classes = "govuk-input--width-10",
           id = lookupForm("postcode").id,
-          errorMessage = lookupForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+          errorMessage = lookupForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
 
         <p class="govuk-!-margin-bottom-6 govuk-body">
             <a class="govuk-link" href="@{routes.AbpAddressLookupController.edit(id)}" id="manualAddress">@{messages("lookupPage.manualAddressLinkText")}</a>
@@ -80,7 +80,7 @@
           value = lookupForm("filter").value,
           classes = "govuk-input--width-20",
           id = lookupForm("filter").id,
-          errorMessage = lookupForm("filter").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message))),
+          errorMessage = lookupForm("filter").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error")))),
           hint = Some(Hint(content = HtmlContent(messages("constants.lookupFilterHint"))))))
 
       @button(Button(content = HtmlContent(messages("lookupPage.submitLabel")),

--- a/app/views/abp/non_uk_mode_edit.scala.html
+++ b/app/views/abp/non_uk_mode_edit.scala.html
@@ -73,32 +73,32 @@ select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
         label = Label(content = HtmlContent(messages("editPage.organisationLabel"))),
         formGroupClasses = "form-field-group", autocomplete = Some("organization"),
         name = editForm("organisation").name, id = editForm("organisation").name, classes = "govuk-input--width-20",
-        errorMessage = editForm("organisation").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("organisation").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("line1").value,
         label = Label(content = HtmlContent(messages("editPage.line1Label"))),
         formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line1"),
         name = editForm("line1").name, id = editForm("line1").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-        errorMessage = editForm("line1").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("line1").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("line2").value,
         label = Label(content = HtmlContent(messages("editPage.line2Label"))),
         formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line2"),
         name = editForm("line2").name, id = editForm("line2").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-        errorMessage = editForm("line2").error.map(fe ⇒ ErrorMessage(content = HtmlContent("DUMMY")))))
+        errorMessage = editForm("line2").error.map(fe ⇒ ErrorMessage(content = HtmlContent("DUMMY"), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("line3").value,
         label = Label(content = HtmlContent(messages("editPage.line3Label"))),
         formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line3"),
         name = editForm("line3").name, id = editForm("line3").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-        errorMessage = editForm("line3").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("line3").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("town").value,
         label = Label(content = HtmlContent(messages("editPage.townLabel"))),
         formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-level1"),
         name = editForm("town").name, id = editForm("town").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-        errorMessage = editForm("town").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("town").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("postcode").value,
         label = Label(content = HtmlContent(messages("editPage.postcodeLabel"))),
         formGroupClasses = "form-field-group", autocomplete = Some("postal-code"),
         name = editForm("postcode").name, id = editForm("postcode").name, classes = "govuk-input--width-10",
-        errorMessage = editForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
 
     @if(journeyData.countryCode.isDefined) {
 
@@ -108,7 +108,7 @@ select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
             label = Label(content = HtmlContent(messages("editPage.countryLabel"))),
             formGroupClasses = "form-field-group", autocomplete = Some("country"),
             name = "countryName", id = "countryName",
-            errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+            errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
 
         <input type="hidden" id="countryCode" name="countryCode" value="@editForm("countryCode").value" />
     } else {
@@ -117,7 +117,7 @@ select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
             id = "countryCode",
             name = "countryCode",
             label = Label(content = HtmlContent(messages("editPage.countryLabel"))),
-            errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message))),
+            errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error")))),
             items = Seq(SelectItem(value = Some(""), text = "Select a country")) ++ countries.map {
                 case (k, v) ⇒ SelectItem(
                     value = Some(k),

--- a/app/views/abp/select.scala.html
+++ b/app/views/abp/select.scala.html
@@ -57,7 +57,7 @@ page: page_template)
 
         @radios(Radios(
             formGroupClasses = "form-group",
-            errorMessage = selectForm("addressId").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message))),
+            errorMessage = selectForm("addressId").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error")))),
             name = "addressId",
             fieldset = Some(Fieldset(
                 legend = Some(Legend(

--- a/app/views/abp/uk_mode_edit.scala.html
+++ b/app/views/abp/uk_mode_edit.scala.html
@@ -71,30 +71,30 @@ select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
         label = Label(content = HtmlContent(messages("editPage.organisationLabel"))),
         formGroupClasses = "form-field-group", autocomplete = Some("organization"),
         name = editForm("organisation").name, id = editForm("organisation").name, classes = "govuk-input--width-20",
-        errorMessage = editForm("organisation").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("organisation").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("line1").value,
         label = Label(content = HtmlContent(messages("editPage.line1Label"))),
         formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line1"),
         name = editForm("line1").name, id = editForm("line1").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-        errorMessage = editForm("line1").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("line1").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("line2").value,
         label = Label(content = HtmlContent(messages("editPage.line2Label"))),
         formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line2"),
         name = editForm("line2").name, id = editForm("line2").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-        errorMessage = editForm("line2").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("line2").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("line3").value,
         label = Label(content = HtmlContent(messages("editPage.line3Label"))),
         formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line3"),
         name = editForm("line3").name, id = editForm("line3").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-        errorMessage = editForm("line3").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("line3").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("town").value,
         label = Label(content = HtmlContent(messages("editPage.townLabel"))),
         formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-level1"),
         name = editForm("town").name, id = editForm("town").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-        errorMessage = editForm("town").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("town").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("postcode").value,
         label = Label(content = HtmlContent(messages("editPage.postcodeLabel.ukMode"))),
         formGroupClasses = "form-field-group", autocomplete = Some("postal-code"),
         name = editForm("postcode").name, id = editForm("postcode").name, classes = "govuk-input--width-10",
-        errorMessage = editForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
 }

--- a/app/views/country_picker.scala.html
+++ b/app/views/country_picker.scala.html
@@ -64,7 +64,7 @@
           id = "countryCode",
           name = "countryCode",
           label = Label(content = HtmlContent(messages("countryPickerPage.countryLabel"))),
-          errorMessage = countryPickerForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message))),
+          errorMessage = countryPickerForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error")))),
           items = Seq(SelectItem(value = Some(""), text = "Select a country")) ++ countries.map {
               case (k, v) ⇒ SelectItem(
                   value = Some(k),

--- a/app/views/international/edit.scala.html
+++ b/app/views/international/edit.scala.html
@@ -79,32 +79,32 @@ select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
         label = Label(content = HtmlContent(internationalMessage("editPage.organisationLabel"))),
         formGroupClasses = "form-field-group", autocomplete = Some("organization"),
         name = editForm("organisation").name, id = editForm("organisation").name, classes = "govuk-input--width-20",
-        errorMessage = editForm("organisation").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("organisation").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("line1").value,
         label = Label(content = HtmlContent(internationalMessage("editPage.line1Label"))),
         formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line1"),
         name = editForm("line1").name, id = editForm("line1").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-        errorMessage = editForm("line1").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("line1").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("line2").value,
         label = Label(content = HtmlContent(internationalMessage("editPage.line2Label"))),
         formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line2"),
         name = editForm("line2").name, id = editForm("line2").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-        errorMessage = editForm("line2").error.map(fe ⇒ ErrorMessage(content = HtmlContent("DUMMY")))))
+        errorMessage = editForm("line2").error.map(fe ⇒ ErrorMessage(content = HtmlContent("DUMMY"), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("line3").value,
         label = Label(content = HtmlContent(internationalMessage("editPage.line3Label"))),
         formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-line3"),
         name = editForm("line3").name, id = editForm("line3").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-        errorMessage = editForm("line3").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("line3").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("town").value,
         label = Label(content = HtmlContent(internationalMessage("editPage.townLabel"))),
         formGroupClasses = s"form-field-group $addressLinesFormGroupErrorClass", autocomplete = Some("address-level1"),
         name = editForm("town").name, id = editForm("town").name, classes = s"govuk-input--width-20 $addressLinesInputErrorClass",
-        errorMessage = editForm("town").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("town").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
     @textInput(Input(value = editForm("postcode").value,
         label = Label(content = HtmlContent(internationalMessage("editPage.postcodeLabel"))),
         formGroupClasses = "form-field-group", autocomplete = Some("postal-code"),
         name = editForm("postcode").name, id = editForm("postcode").name, classes = "govuk-input--width-10",
-        errorMessage = editForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+        errorMessage = editForm("postcode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
 
     @if(journeyData.countryCode.isDefined) {
 
@@ -114,7 +114,7 @@ select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
             label = Label(content = HtmlContent(internationalMessage("editPage.countryLabel"))),
             formGroupClasses = "form-field-group", autocomplete = Some("country"),
             name = "countryName", id = "countryName",
-            errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message)))))
+            errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error"))))))
 
         <input type="hidden" id="countryCode" name="countryCode" value="@editForm("countryCode").value" />
     } else {
@@ -123,7 +123,7 @@ select: GovukSelect, page: page_template, govukFieldset: GovukFieldset)
         id = "countryCode",
         name = "countryCode",
         label = Label(content = HtmlContent(internationalMessage("editPage.countryLabel"))),
-        errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message))),
+        errorMessage = editForm("countryCode").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error")))),
         items = Seq(SelectItem(value = Some(""), text = "Select a country")) ++ countries.map {
             case (k, v) ⇒ SelectItem(
                 value = Some(k),

--- a/app/views/international/lookup.scala.html
+++ b/app/views/international/lookup.scala.html
@@ -73,7 +73,7 @@
           value = lookupForm("filter").value,
           classes = "govuk-input--width-20",
           id = lookupForm("filter").id,
-          errorMessage = lookupForm("filter").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message))),
+          errorMessage = lookupForm("filter").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error")))),
           hint = Some(Hint(content = HtmlContent(internationalMessage("constants.lookupFilterHint"))))))
 
       <p class="govuk-!-margin-bottom-6 govuk-body">

--- a/app/views/international/select.scala.html
+++ b/app/views/international/select.scala.html
@@ -51,7 +51,7 @@
 
         @radios(Radios(
             formGroupClasses = "form-group",
-            errorMessage = selectForm("addressId").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message))),
+            errorMessage = selectForm("addressId").error.map(fe ⇒ ErrorMessage(content = HtmlContent(fe.message), visuallyHiddenText = Some(messages("constants.error")))),
             name = "addressId",
             fieldset = Some(Fieldset(
                 legend = Some(Legend(

--- a/conf/messages
+++ b/conf/messages
@@ -92,6 +92,7 @@ constants.notFoundErrorHeading = This page cannot be found
 constants.notFoundErrorBody = Please check that you have entered the correct web address.
 
 constants.error.prefix = Error:
+constants.error = Error
 
 constants.footer.visuallyHiddenText = Support links
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -92,6 +92,7 @@ constants.notFoundErrorHeading = Ni ellir dod o hyd i’r dudalen hon
 constants.notFoundErrorBody = Gwiriwch eich bod wedi nodi’r cyfeiriad gwe cywir.
 
 constants.error.prefix = Gwall:
+constants.error = Gwall
 
 constants.footer.visuallyHiddenText = Dolenni cymorth
 

--- a/it/controllers/abp/LookupPageISpec.scala
+++ b/it/controllers/abp/LookupPageISpec.scala
@@ -402,6 +402,25 @@ class LookupPageISpec extends IntegrationSpecBase {
         doc.h1 should have(text(messages(Lang("cy"), "constants.intServerErrorTitle")))
         doc.paras should have(elementWithValue(messages(Lang("cy"), "constants.intServerErrorTryAgain")))
       }
+
+      "Show the default 'postcode not entered' error message" in {
+        stubKeystore(testJourneyId, testMinimalLevelJourneyConfigV2, OK)
+        stubKeystoreSave(testJourneyId, testMinimalLevelJourneyConfigV2, OK)
+
+        val fResponse = buildClientLookupAddress(path = "lookup")
+          .withHttpHeaders(HeaderNames.COOKIE -> sessionCookieWithCSRFAndLang(), "Csrf-Token" -> "nocheck")
+          .post("")
+
+        val res = await(fResponse)
+        val doc = getDocFromResponse(res)
+
+        res.status shouldBe BAD_REQUEST
+
+        doc.input(LookupPage.postcodeId) should have(
+          errorMessage("Gwall: error.required"),
+          value("")
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
Error messages have visually hidden text prefixing the message itself to assist people using screen readers, but this visually hidden text is always the English word "Error:" regardless of what language the language cookie is set to.

When the cookie is set to Welsh, it should prefix errors with "Gwall:".