### PR TITLE
[CIR-1986] Allow configurable maxLength for the Manual Entry screens address lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ If your service doesn't have Welsh translations you can disable them setting the
       "showSearchAgainLink": false,
       "showConfirmChangeText": true
     },
+    "manualAddressEntryConfig": {
+      "line1MaxLength": 255,
+      "line2MaxLength": 255,
+      "line3MaxLength": 255,
+      "townMaxLength": 255
+    },
     "timeoutConfig": {
       "timeoutAmount": 900,
       "timeoutUrl": "/timeout-uri",
@@ -260,6 +266,18 @@ Configuration of the "confirm" page, in which the user is requested to confirm a
 |`showSearchAgainLink`|Whether or not to show "search again" link back to lookup page|Optional|Boolean|`false`|
 |`showChangeLink`|Whether or not to show "Edit address" link back to Edit page|Optional|Boolean|`true`|
 |`showConfirmChangeText`|Whether or not to show "confirmChangeText" displayed above the submit button|Optional|Boolean|`false`|
+
+#### Manual Address Entry Configuration JSON object (Optional)
+
+Provides configuration for the manual address entry page, currently this supports setting max lengths for the address lines that are different from the 255 default.
+The manual address entry page configuration is a nested JSON object inside the journey configuration under the `manualAddressEntryConfig` property.
+
+| Field name       | Description                                                          | Optional/Required | Type | Default value |
+|------------------|----------------------------------------------------------------------|-------------------|------|---------------|
+| `line1MaxLength` | Max Length for Line 1 of the Address (must be between 35 and 255)    | Optional          | Int  | 255           |
+| `line2MaxLength` | Max Length for Line 2 of the Address (must be between 35 and 255)    | Optional          | Int  | 255           |
+| `line3MaxLength` | Max Length for Line 3 of the Address (must be between 35 and 255)    | Optional          | Int  | 255           |
+| `townMaxLength`  | Max Length for Town/City of the Address (must be between 35 and 255) | Optional          | Int  | 255           |
 
 #### Timeout Configuration JSON object (Optional)
 

--- a/app/controllers/AbpAddressLookupController.scala
+++ b/app/controllers/AbpAddressLookupController.scala
@@ -299,7 +299,7 @@ class AbpAddressLookupController @Inject()(
               uk_mode_edit(
                 id,
                 journeyData,
-                ukEditForm().fill(editAddress),
+                ukEditForm(journeyData.config.options.manualAddressEntryConfig).fill(editAddress),
                 allowedSeqCountries(Seq.empty),
                 isWelsh,
                 isUKMode
@@ -313,7 +313,7 @@ class AbpAddressLookupController @Inject()(
               non_uk_mode_edit(
                 id,
                 journeyData,
-                nonUkEditForm().fill(defaultAddress),
+                nonUkEditForm(journeyData.config.options.manualAddressEntryConfig).fill(defaultAddress),
                 allowedSeqCountries(countries(isWelsh)),
                 isWelsh = isWelsh,
                 isUKMode = isUKMode
@@ -378,7 +378,7 @@ class AbpAddressLookupController @Inject()(
         val isUKMode = journeyData.config.options.isUkMode
 
         if (isUKMode) {
-          val validatedForm = isValidPostcode(ukEditForm().bindFromRequest())
+          val validatedForm = isValidPostcode(ukEditForm(journeyData.config.options.manualAddressEntryConfig).bindFromRequest())
 
           validatedForm.fold(
             errors =>
@@ -411,7 +411,7 @@ class AbpAddressLookupController @Inject()(
           )
         } else {
           val validatedForm =
-            isValidPostcode(nonUkEditForm().bindFromRequest())
+            isValidPostcode(nonUkEditForm(journeyData.config.options.manualAddressEntryConfig).bindFromRequest())
 
           validatedForm.fold(
             errors => {

--- a/app/controllers/InternationalAddressLookupController.scala
+++ b/app/controllers/InternationalAddressLookupController.scala
@@ -261,7 +261,7 @@ class InternationalAddressLookupController @Inject()(
             edit(
               id,
               journeyData,
-              nonUkEditForm().fill(defaultAddress),
+              nonUkEditForm(journeyData.config.options.manualAddressEntryConfig).fill(defaultAddress),
               allowedSeqCountries(countries(isWelsh)),
               isWelsh = isWelsh
             )
@@ -294,7 +294,7 @@ class InternationalAddressLookupController @Inject()(
         val isWelsh = getWelshContent(journeyData)
 
         val validatedForm =
-          isValidPostcode(nonUkEditForm().bindFromRequest())
+          isValidPostcode(nonUkEditForm(journeyData.config.options.manualAddressEntryConfig).bindFromRequest())
 
         validatedForm.fold(
           errors => {

--- a/app/forms/ALFForms.scala
+++ b/app/forms/ALFForms.scala
@@ -103,17 +103,19 @@ object ALFForms extends EmptyStringValidator {
     )(Select.apply)(Select.unapply)
   )
 
-  val constraintOptString256 = (msg: String) => new Constraint[Option[String]](Some("length.max"), Seq.empty)(s => if (s.isEmpty || s.get.length < 256) {
-    Valid
-  } else {
-    Invalid(msg)
-  })
+  def constraintOptStringMaxLength(msg: String, max: Int) =
+    new Constraint[Option[String]](Some("length.max"), Seq.empty)(s => if (s.isEmpty || s.get.length <= max) {
+      Valid
+    } else {
+      Invalid(msg, max)
+    })
 
-  val constraintString256 = (msg: String) => new Constraint[String](Some("length.max"), Seq.empty)(s => if (s.length < 256) {
-    Valid
-  } else {
-    Invalid(msg)
-  })
+  def constraintStringMaxLength(msg: String, max: Int) =
+    new Constraint[String](Some("length.max"), Seq.empty)(s => if (s.length <= max) {
+      Valid
+    } else {
+      Invalid(msg, max)
+    })
 
   val constraintMinLength = (msg: String) => new Constraint[String](Some("length.min"), Seq.empty)(s => if (s.nonEmpty) {
     Valid
@@ -147,30 +149,35 @@ object ALFForms extends EmptyStringValidator {
     override def unbind(key: String, value: Option[String]): Map[String, String] = Map(key -> value.getOrElse(""))
   }
 
-  def ukEditForm()(implicit messages: Messages): Form[Edit] = Form(
+  def ukEditForm(optConfig: Option[ManualAddressEntryConfig] = None)(implicit messages: Messages): Form[Edit] = {
+    val config = optConfig getOrElse ManualAddressEntryConfig()
+    Form(
     mapping(
       "organisation" -> optional(text),
-      "line1" -> atLeastOneAddressLineOrTown(messages(s"constants.editPageAtLeastOneLineOrTown")).verifying(constraintOptString256(messages(s"constants.editPageAddressLine1MaxErrorMessage"))),
-      "line2" -> optional(text).verifying(constraintOptString256(messages(s"constants.editPageAddressLine2MaxErrorMessage"))),
-      "line3" -> optional(text).verifying(constraintOptString256(messages(s"constants.editPageAddressLine3MaxErrorMessage"))),
-      "town" -> optional(text).verifying(constraintOptString256(messages(s"constants.editPageTownMaxErrorMessage"))),
+      "line1" -> atLeastOneAddressLineOrTown(messages(s"constants.editPageAtLeastOneLineOrTown")).verifying(constraintOptStringMaxLength(messages(s"constants.editPageAddressLine1MaxErrorMessage", config.line1MaxLength + 1), config.line1MaxLength)),
+      "line2" -> optional(text).verifying(constraintOptStringMaxLength(messages(s"constants.editPageAddressLine2MaxErrorMessage", config.line2MaxLength + 1), config.line2MaxLength)),
+      "line3" -> optional(text).verifying(constraintOptStringMaxLength(messages(s"constants.editPageAddressLine3MaxErrorMessage", config.line3MaxLength + 1), config.line3MaxLength)),
+      "town" -> optional(text).verifying(constraintOptStringMaxLength(messages(s"constants.editPageTownMaxErrorMessage", config.townMaxLength + 1), config.townMaxLength)),
       "postcode" -> default(text, ""),
       "countryCode" -> ignored[String]("GB")
     )(Edit.apply)(Edit.unapply)
   )
+  }
 
-  def nonUkEditForm()(implicit messages: Messages) =
+  def nonUkEditForm(optConfig: Option[ManualAddressEntryConfig] = None)(implicit messages: Messages) = {
+    val config = optConfig getOrElse ManualAddressEntryConfig()
     Form(
       mapping(
         "organisation" -> optional(text),
-        "line1" -> atLeastOneAddressLineOrTown(messages(s"constants.editPageAtLeastOneLineOrTown")).verifying(constraintOptString256(messages(s"constants.editPageAddressLine1MaxErrorMessage"))),
-        "line2" -> optional(text).verifying(constraintOptString256(messages(s"constants.editPageAddressLine2MaxErrorMessage"))),
-        "line3" -> optional(text).verifying(constraintOptString256(messages(s"constants.editPageAddressLine3MaxErrorMessage"))),
-        "town" -> optional(text).verifying(constraintOptString256(messages(s"constants.editPageTownMaxErrorMessage"))),
+        "line1" -> atLeastOneAddressLineOrTown(messages(s"constants.editPageAtLeastOneLineOrTown")).verifying(constraintOptStringMaxLength(messages(s"constants.editPageAddressLine1MaxErrorMessage", config.line1MaxLength + 1), config.line1MaxLength)),
+        "line2" -> optional(text).verifying(constraintOptStringMaxLength(messages(s"constants.editPageAddressLine2MaxErrorMessage", config.line2MaxLength + 1), config.line2MaxLength)),
+        "line3" -> optional(text).verifying(constraintOptStringMaxLength(messages(s"constants.editPageAddressLine3MaxErrorMessage", config.line3MaxLength + 1), config.line3MaxLength)),
+        "town" -> optional(text).verifying(constraintOptStringMaxLength(messages(s"constants.editPageTownMaxErrorMessage", config.townMaxLength + 1), config.townMaxLength)),
         "postcode" -> default(text, ""),
         "countryCode" -> customErrorTextValidation(messages(s"constants.editPageCountryErrorMessage"))
       )(Edit.apply)(Edit.unapply)
     )
+  }
 
   def countryPickerForm()(implicit messages: Messages) =
     Form(

--- a/app/model/ModelV2.scala
+++ b/app/model/ModelV2.scala
@@ -39,15 +39,24 @@ case class JourneyConfigV2(version: Int,
                            labels: Option[JourneyLabels] = None, //messages
                            requestedVersion: Option[Int] = None)
 
-case class JourneyOptions(continueUrl: String, homeNavHref: Option[String] = None, signOutHref: Option[String] = None,
-                          accessibilityFooterUrl: Option[String] = None, phaseFeedbackLink: Option[String] = None,
-                          deskProServiceName: Option[String] = None, showPhaseBanner: Option[Boolean] = None,
-                          alphaPhase: Option[Boolean] = None, showBackButtons: Option[Boolean] = None,
-                          disableTranslations: Option[Boolean] = None, includeHMRCBranding: Option[Boolean] = None,
-                          ukMode: Option[Boolean] = None, allowedCountryCodes: Option[Set[String]] = None,
+case class JourneyOptions(continueUrl: String,
+                          homeNavHref: Option[String] = None,
+                          signOutHref: Option[String] = None,
+                          accessibilityFooterUrl: Option[String] = None,
+                          phaseFeedbackLink: Option[String] = None,
+                          deskProServiceName: Option[String] = None,
+                          showPhaseBanner: Option[Boolean] = None,
+                          alphaPhase: Option[Boolean] = None,
+                          showBackButtons: Option[Boolean] = None,
+                          disableTranslations: Option[Boolean] = None,
+                          includeHMRCBranding: Option[Boolean] = None,
+                          ukMode: Option[Boolean] = None,
+                          allowedCountryCodes: Option[Set[String]] = None,
                           selectPageConfig: Option[SelectPageConfig] = None,
                           confirmPageConfig: Option[ConfirmPageConfig] = None,
-                          timeoutConfig: Option[TimeoutConfig] = None, serviceHref: Option[String] = None,
+                          manualAddressEntryConfig: Option[ManualAddressEntryConfig] = None,
+                          timeoutConfig: Option[TimeoutConfig] = None,
+                          serviceHref: Option[String] = None,
                           pageHeadingStyle: Option[String] = None) {
 
   val isUkMode: Boolean = ukMode contains true
@@ -61,6 +70,12 @@ case class ConfirmPageConfig(showSearchAgainLink: Option[Boolean] = None,
                              showSubHeadingAndInfo: Option[Boolean] = None,
                              showChangeLink: Option[Boolean] = None,
                              showConfirmChangeText: Option[Boolean] = None)
+
+case class ManualAddressEntryConfig(strictValidation: Boolean = false,
+                                    line1MaxLength: Int = 35, //limit only used if strictValidation=`true`
+                                    line2MaxLength: Int = 35, //limit only used if strictValidation=`true`
+                                    line3MaxLength: Int = 35, //limit only used if strictValidation=`true`
+                                    townMaxLength: Int = 35)  //limit only used if strictValidation=`true`
 
 case class TimeoutConfig(timeoutAmount: Int,
                          timeoutUrl: String,
@@ -90,6 +105,10 @@ object JourneyOptions {
 
 object SelectPageConfig {
   implicit val format: Format[SelectPageConfig] = Json.format[SelectPageConfig]
+}
+
+object ManualAddressEntryConfig {
+  implicit val format: Format[ManualAddressEntryConfig] = Json.format[ManualAddressEntryConfig]
 }
 
 object ConfirmPageConfig {

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -10,14 +10,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/connector.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
+            <pattern>[%highlight(%.-4level)][%replace(%logger){'.*\.(.*)','$1'}] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
         </encoder>
     </appender>
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -10,14 +10,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/connector.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
+            <pattern>[%highlight(%.-4level)][%replace(%logger){'.*\.(.*)','$1'}] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
         </encoder>
     </appender>
 

--- a/conf/messages
+++ b/conf/messages
@@ -35,10 +35,10 @@ constants.forPostcode = for postcode
 constants.postcodeLabel.ukMode = UK postcode (optional)
 constants.postcodeLabel = Postcode (optional)
 
-constants.editPageAddressLine1MaxErrorMessage = The first address line needs to be fewer than 256 characters
-constants.editPageAddressLine2MaxErrorMessage = The second address line needs to be fewer than 256 characters
-constants.editPageAddressLine3MaxErrorMessage = The third address line needs to be fewer than 256 characters
-constants.editPageTownMaxErrorMessage = The town or city needs to be fewer than 256 characters
+constants.editPageAddressLine1MaxErrorMessage = The first address line needs to be fewer than {0} characters
+constants.editPageAddressLine2MaxErrorMessage = The second address line needs to be fewer than {0} characters
+constants.editPageAddressLine3MaxErrorMessage = The third address line needs to be fewer than {0} characters
+constants.editPageTownMaxErrorMessage = The town or city needs to be fewer than {0} characters
 constants.editPageAddressLine1MinErrorMessage = Enter the first line of address
 constants.editPageTownMinErrorMessage = Enter the town or city
 constants.editPagePostcodeErrorMessage.ukMode = Enter a valid UK postcode

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -35,10 +35,10 @@ constants.forPostcode = am y cod post
 constants.postcodeLabel.ukMode = Cod post yn y DU (dewisol)
 constants.postcodeLabel = Cod post (dewisol)
 
-constants.editPageAddressLine1MaxErrorMessage = Mae angen i linell gyntaf y cyfeiriad fod yn llai na 256 o gymeriadau
-constants.editPageAddressLine2MaxErrorMessage = Mae angen i ail linell y cyfeiriad fod yn llai na 256 o gymeriadau
-constants.editPageAddressLine3MaxErrorMessage = Mae angen i drydedd linell y cyfeiriad fod yn llai na 256 o gymeriadau
-constants.editPageTownMaxErrorMessage = Mae angen i’r dref neu’r ddinas fod yn llai na 256 o gymeriadau
+constants.editPageAddressLine1MaxErrorMessage = Mae angen i linell gyntaf y cyfeiriad fod yn llai na {0} o gymeriadau
+constants.editPageAddressLine2MaxErrorMessage = Mae angen i ail linell y cyfeiriad fod yn llai na {0} o gymeriadau
+constants.editPageAddressLine3MaxErrorMessage = Mae angen i drydedd linell y cyfeiriad fod yn llai na {0} o gymeriadau
+constants.editPageTownMaxErrorMessage = Mae angen i’r dref neu’r ddinas fod yn llai na {0} o gymeriadau
 constants.editPageAddressLine1MinErrorMessage = Nodwch linell gyntaf y cyfeiriad
 constants.editPageTownMinErrorMessage = Nodwch y dref neu’r ddinas
 constants.editPagePostcodeErrorMessage.ukMode = Nodwch god post yn y DU sy’n ddilys

--- a/it/test/controllers/ApiControllerV2ISpec.scala
+++ b/it/test/controllers/ApiControllerV2ISpec.scala
@@ -133,11 +133,10 @@ class ApiControllerV2ISpec extends IntegrationSpecBase {
             version = testApiVersion,
             options = JourneyOptions(continueUrl = testContinueUrl, manualAddressEntryConfig = Some(
               ManualAddressEntryConfig(
-                strictValidation = true,
-                line1MaxLength = 40,
-                line2MaxLength = 50,
-                line3MaxLength = 60,
-                townMaxLength = 70
+                line1MaxLength = 50,
+                line2MaxLength = 60,
+                line3MaxLength = 70,
+                townMaxLength = 80
               )
             ))
           )

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,9 +2,9 @@ import play.sbt.PlayImport.*
 import sbt.*
 
 object AppDependencies {
-  private val bootstrapPlayVersion = "9.13.0"
-  private val hmrcFrontendPlayVersion = "12.5.0"
-  private val hmrcMongoPlayVersion = "2.6.0"
+  private val bootstrapPlayVersion = "9.18.0"
+  private val hmrcFrontendPlayVersion = "12.7.0"
+  private val hmrcMongoPlayVersion = "2.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     ws,
@@ -20,12 +20,12 @@ object AppDependencies {
   def test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-test-play-30"   % bootstrapPlayVersion  % Test,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30"  % hmrcMongoPlayVersion  % Test,
-    "org.jsoup"          % "jsoup"                    % "1.20.1"              % Test,
+    "org.jsoup"          % "jsoup"                    % "1.21.1"              % Test,
   )
 
   def it: Seq[sbt.ModuleID] = Seq(
-    "com.fasterxml.jackson.core"     % "jackson-databind"     % "2.19.0" % Test,
-    "com.fasterxml.jackson.module"  %% "jackson-module-scala" % "2.19.0" % Test
+    "com.fasterxml.jackson.core"     % "jackson-databind"     % "2.19.2" % Test,
+    "com.fasterxml.jackson.module"  %% "jackson-module-scala" % "2.19.2" % Test
   )
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,8 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.7")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
-addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
+addSbtPlugin("uk.gov.hmrc"        % "sbt-auto-build"      % "3.24.0")
+addSbtPlugin("uk.gov.hmrc"        % "sbt-distributables"  % "2.6.0")
+addSbtPlugin("org.playframework"  % "sbt-plugin"          % "3.0.8")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage"       % "2.3.1")
+addSbtPlugin("io.github.irundaia" % "sbt-sassify"         % "1.5.2")

--- a/test/model/ModelV2Spec.scala
+++ b/test/model/ModelV2Spec.scala
@@ -102,6 +102,57 @@ class ModelV2Spec extends AnyWordSpecLike with Matchers with GuiceOneAppPerSuite
     }
   }
 
+  "Manual Address Entry Config" when {
+
+    "deserializing from JSON" should {
+
+      "fail to read if a value is smaller than the minimum allowed (35)" in {
+        Json.fromJson[ManualAddressEntryConfig](Json.obj(
+          "line1MaxLength" -> 34,
+          "line2MaxLength" -> 60,
+          "line3MaxLength" -> 70,
+          "townMaxLength" -> 80
+        )) mustBe JsError(JsPath \ "line1MaxLength", JsonValidationError("error.min", 35))
+      }
+
+      "fail to read if a value is greater than the max allowed (255)" in {
+        Json.fromJson[ManualAddressEntryConfig](Json.obj(
+          "line1MaxLength" -> 256,
+          "line2MaxLength" -> 60,
+          "line3MaxLength" -> 70,
+          "townMaxLength" -> 80
+        )) mustBe JsError(JsPath \ "line1MaxLength", JsonValidationError("error.max", 255))
+      }
+
+      "read successfully from max json" in {
+        Json.fromJson[ManualAddressEntryConfig](Json.obj(
+          "line1MaxLength" -> 50,
+          "line2MaxLength" -> 60,
+          "line3MaxLength" -> 70,
+          "townMaxLength" -> 80
+        )) mustBe JsSuccess(ManualAddressEntryConfig(
+          line1MaxLength = 50,
+          line2MaxLength = 60,
+          line3MaxLength = 70,
+          townMaxLength = 80
+        ))
+      }
+
+      "read successfully from minimal json" in {
+        Json.fromJson[ManualAddressEntryConfig](emptyJson) mustBe JsSuccess(ManualAddressEntryConfig())
+      }
+    }
+
+    "serialize to json" in {
+      Json.toJson(ManualAddressEntryConfig()) mustBe Json.obj(
+        "line1MaxLength" -> ManualAddressEntryConfig.defaultMax,
+        "line2MaxLength" -> ManualAddressEntryConfig.defaultMax,
+        "line3MaxLength" -> ManualAddressEntryConfig.defaultMax,
+        "townMaxLength" -> ManualAddressEntryConfig.defaultMax
+      )
+    }
+  }
+
   "TimeoutConfig" should {
     "fail to read from json with timeout amount missing" in {
       Json.fromJson[TimeoutConfig](timeoutConfigLessThanMinJson) mustBe JsError(JsPath \ "timeoutAmount", JsonValidationError("error.min", 120))

--- a/test/utils/TestConstants.scala
+++ b/test/utils/TestConstants.scala
@@ -152,9 +152,11 @@ object TestConstants {
 
   val fullV2ConfirmPageConfig = Some(ConfirmPageConfig(Confirm.showSearchAgainLink, Confirm.showSubHeading, Confirm.showChangeLink, Confirm.showConfirmChangeLink))
 
+  val fullV2ManualAddressEntryConfig = Some(ManualAddressEntryConfig(strictValidation = true))
+
   val fullV2TimeoutConfig = Some(TimeoutConfig(testTimeoutAmount, testTimeoutUrl, testTimeoutKeepAliveUrl))
 
-  val fullV2JourneyOptions = JourneyOptions(testContinueUrl, testHomeNavRef, testSignOutHref, testAccessibilityFooterUrl, testPhaseFeedbackLink, testDeskproServiceName, testShowPhaseBanner, testAlphaPhase, testDisableTranslations, testShowBackButtons, testIncludeHmrcBranding, testUkMode, testAllowedCountryCodes, fullV2SelectPageConfig, fullV2ConfirmPageConfig, fullV2TimeoutConfig)
+  val fullV2JourneyOptions = JourneyOptions(testContinueUrl, testHomeNavRef, testSignOutHref, testAccessibilityFooterUrl, testPhaseFeedbackLink, testDeskproServiceName, testShowPhaseBanner, testAlphaPhase, testDisableTranslations, testShowBackButtons, testIncludeHmrcBranding, testUkMode, testAllowedCountryCodes, fullV2SelectPageConfig, fullV2ConfirmPageConfig, fullV2ManualAddressEntryConfig, fullV2TimeoutConfig)
 
   val fullV2LanguageLabelsEn = LanguageLabels(
     appLevelLabels = fullV2AppLabels,
@@ -232,11 +234,12 @@ object TestConstants {
                                     testAllowedCountryCodes: Option[Set[String]] = testAllowedCountryCodes,
                                     testSelectPage: Option[SelectPageConfig] = fullV2SelectPageConfig,
                                     testTimeoutConfig: Option[TimeoutConfig] = fullV2TimeoutConfig,
+                                    testManualAddressEntryConfig: Option[ManualAddressEntryConfig] = fullV2ManualAddressEntryConfig,
                                     testConfirmPageConfig: Option[ConfirmPageConfig] = confirmPageConfigFull,
                                     testLabels: Option[JourneyLabels] = fullV2JourneyLabelsEn
                                    ): JourneyDataV2 = {
 
-    val journeyOptions = JourneyOptions(testContinueUrl, testHomeNavHref, testSignOutHref, testAccessibilityFooterUrl, testPhaseFeedbackLink, testDeskProServiceName, testShowPhaseBanner, testAlphaPhase, testShowBackButtons, testDisableTranslations, testIncludeHMRCBranding, testUkMode, testAllowedCountryCodes, testSelectPage, testConfirmPageConfig, testTimeoutConfig)
+    val journeyOptions = JourneyOptions(testContinueUrl, testHomeNavHref, testSignOutHref, testAccessibilityFooterUrl, testPhaseFeedbackLink, testDeskProServiceName, testShowPhaseBanner, testAlphaPhase, testShowBackButtons, testDisableTranslations, testIncludeHMRCBranding, testUkMode, testAllowedCountryCodes, testSelectPage, testConfirmPageConfig, testManualAddressEntryConfig, testTimeoutConfig)
 
     JourneyDataV2(
       JourneyConfigV2(

--- a/test/utils/TestConstants.scala
+++ b/test/utils/TestConstants.scala
@@ -152,7 +152,7 @@ object TestConstants {
 
   val fullV2ConfirmPageConfig = Some(ConfirmPageConfig(Confirm.showSearchAgainLink, Confirm.showSubHeading, Confirm.showChangeLink, Confirm.showConfirmChangeLink))
 
-  val fullV2ManualAddressEntryConfig = Some(ManualAddressEntryConfig(strictValidation = true))
+  val fullV2ManualAddressEntryConfig = Some(ManualAddressEntryConfig())
 
   val fullV2TimeoutConfig = Some(TimeoutConfig(testTimeoutAmount, testTimeoutUrl, testTimeoutKeepAliveUrl))
 
@@ -209,7 +209,7 @@ object TestConstants {
 
   val selectPageConfigMinimal = SelectPageConfig(None, None)
 
-  val journeyOptionsMinimal = JourneyOptions("testUrl", None, None, None, None, None, None, None, None, None, None, None, None, None, None, None)
+  val journeyOptionsMinimal = JourneyOptions("testUrl", None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None)
   val journeyOptionsMinimalJson: JsValue = Json.parse("""{"continueUrl":"testUrl"}""")
 
   val journeyConfigV2 = JourneyConfigV2(2, journeyOptionsMinimal, Some(journeyLabelsMinimal))


### PR DESCRIPTION
- New config model `ManualAddressEntryConfig` that includes four configurable values for line 1, 2, 3 and Town/City
- This has been added as an `Option` to the existing `JourneyConfig` model
- If a value is supplied, then use that for Form validation. Else, use the default (255). Messages updated to take an argument for the max length value so that the message is correct
- Updated UT and IT tests 🟢 