### PR TITLE
[CIR-cookie-secure-false] Roll back secure cookies to false

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -46,6 +46,13 @@ play.filters {
 //play.modules.enabled += "com.kenshoo.play.metrics.PlayModule"
 play.i18n.langs = ["en", "cy"]
 
+# Session configuration
+# ~~~~~
+#TODO: 9.15.0 of Bootstrap sets all the below to `true`, but causes issues for us during Perf Testing. Need to investigate.
+play.http.session.secure     = false
+play.http.flash.secure       = false
+play.i18n.langCookieSecure   = false
+
 footerLinkItems = ["cookies", "privacy", "termsConditions", "govukHelp"]
 
 # Global request handler

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,6 +2,7 @@ import play.sbt.PlayImport.*
 import sbt.*
 
 object AppDependencies {
+
   private val bootstrapPlayVersion = "9.18.0"
   private val hmrcFrontendPlayVersion = "12.7.0"
   private val hmrcMongoPlayVersion = "2.7.0"


### PR DESCRIPTION
9.15.0 of bootstrap sets them to true but this has caused some CSRF failures during performance testing - needs investigating further.
- https://github.com/hmrc/bootstrap-play/releases/tag/v9.15.0

For now, I've rolled back the conf to false locally.