### PR TITLE
CIR-2649 Honour the includeHMRCBranding configuration option

### DIFF
--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -74,7 +74,7 @@
         banners = {
             if (resolvedJourneyConfig.options.showPhaseBanner) {
                 Banners(
-                    displayHmrcBanner = true,
+                    displayHmrcBanner = resolvedJourneyConfig.options.includeHMRCBranding,
                     phaseBanner = Some(
                         PhaseBanner(
                             tag = Some(Tag(
@@ -88,7 +88,7 @@
                 )
             }
             else {
-                Banners(displayHmrcBanner = true)
+                Banners(displayHmrcBanner = resolvedJourneyConfig.options.includeHMRCBranding)
             }
         },
         templateOverrides = TemplateOverrides(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ import sbt.*
 object AppDependencies {
 
   private val bootstrapPlayVersion = "10.5.0"
-  private val hmrcFrontendPlayVersion = "12.25.0"
+  private val hmrcFrontendPlayVersion = "12.26.0"
   private val hmrcMongoPlayVersion = "2.11.0"
   private val jacksonVersion = "3.0.3"
 

--- a/test/views/CountryPickerViewSpec.scala
+++ b/test/views/CountryPickerViewSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import address.v2.Country
+import config.FrontendAppConfig
+import forms.ALFForms.countryPickerForm
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.i18n.{Lang, MessagesApi}
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import utils.TestConstants.*
+import views.html.country_picker
+
+class CountryPickerViewSpec extends ViewSpec {
+
+  implicit val lang: Lang = Lang("en")
+  val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  val countryPickerView: country_picker = app.injector.instanceOf[country_picker]
+  implicit val frontendAppConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
+
+  private def renderPage(showPhaseBanner: Option[Boolean], includeHMRCBranding: Option[Boolean]): Document = {
+    val testJourneyConfig = fullV2JourneyDataCustomConfig(
+      testShowPhaseBanner = showPhaseBanner,
+      testIncludeHMRCBranding = includeHMRCBranding
+    )
+    val testPage: Html = countryPickerView("", testJourneyConfig, countryPickerForm(), isWelsh = false, countries = Seq.empty[Country])(FakeRequest())
+    Jsoup.parse(testPage.body)
+  }
+
+  "the phase banner is ENABLED" should {
+    "show the HMRC branding when explicitly set to true" in {
+      renderPage(Some(true), Some(true)).select("div.hmrc-banner").size.shouldBe(1)
+    }
+
+    "NOT show the HMRC branding when explicitly set to false" in {
+      renderPage(Some(true), Some(false)).select("div.hmrc-banner").size.shouldBe(0)
+    }
+  }
+
+  "the phase banner is DISABLED" should {
+    "show the HMRC branding when explicitly set to true" in {
+      renderPage(Some(false), Some(true)).select("div.hmrc-banner").size.shouldBe(1)
+    }
+
+    "NOT show the HMRC branding when explicitly set to false" in {
+      renderPage(Some(false), Some(false)).select("div.hmrc-banner").size.shouldBe(0)
+    }
+  }
+
+}


### PR DESCRIPTION
This pull request updates how HMRC branding is displayed in the UI and adds new tests to verify this behavior. The main focus is to ensure that the display of the HMRC banner is controlled by the `includeHMRCBranding` configuration option, both when the phase banner is enabled and disabled.

The most important changes are:

**UI Logic Updates:**

* Updated the `app/views/templates/Layout.scala.html` template to use the `includeHMRCBranding` option instead of always displaying the HMRC banner, ensuring the banner only appears when explicitly configured. [[1]](diffhunk://#diff-33a021a0ded7714fce6e20ac19e5580e8d6b0595384a603724d26a4d12a0a896L77-R77) [[2]](diffhunk://#diff-33a021a0ded7714fce6e20ac19e5580e8d6b0595384a603724d26a4d12a0a896L91-R91)

**Testing Enhancements:**

* Added a new test suite `CountryPickerViewSpec.scala` to verify that the HMRC banner appears or is hidden according to the `includeHMRCBranding` and `showPhaseBanner` options. This ensures correct UI behavior for different configuration scenarios.