### PR TITLE
CIR-2879 Support overriding of address line error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ If your service doesn't have Welsh translations you can disable them setting the
         "town": true,
         "postcode": true
       },
+      "maxLengthErrorMessages": {
+        "en": {
+          "addressLine1": "Custom error message for address line 1",
+          "addressLine2": "Custom error message for address line 2",
+          "addressLine3": "Custom error message for address line 3",
+          "town": "Custom error message for town"
+        },
+        "cy": {
+          "addressLine1": "Custom error message for address line 1 - Welsh",
+          "addressLine2": "Custom error message for address line 2 - Welsh",
+          "addressLine3": "Custom error message for address line 3 - Welsh",
+          "town": "Custom error message for town - Welsh"
+        }
+      },
       "showOrganisationName": true
     },
     "timeoutConfig": {
@@ -307,14 +321,23 @@ Configuration of the "confirm" page, in which the user is requested to confirm a
 Provides configuration for the manual address entry page, currently this supports setting max lengths for the address lines that are different from the 255 default.
 The manual address entry page configuration is a nested JSON object inside the journey configuration under the `manualAddressEntryConfig` property.
 
-| Field name             | Description                                                                         | Optional/Required | Type    | Default value |
-|------------------------|-------------------------------------------------------------------------------------|-------------------|---------|---------------|
-| `line1MaxLength`       | Max Length for Line 1 of the Address (must be between 35 and 255)                   | Optional          | Int     | 255           |
-| `line2MaxLength`       | Max Length for Line 2 of the Address (must be between 35 and 255)                   | Optional          | Int     | 255           |
-| `line3MaxLength`       | Max Length for Line 3 of the Address (must be between 35 and 255)                   | Optional          | Int     | 255           |
-| `townMaxLength`        | Max Length for Town/City of the Address (must be between 35 and 255)                | Optional          | Int     | 255           |
-| `mandatoryFields`      | List of fields that are mandatory for the address to be valid                       | Optional          | Model   | None          |
-| `showOrganisationName` | Whether or not to show the organisation name field on the manual address entry page | Optional          | Boolean | True          |
+`maxLengthErrorMessages` is a nested JSON object which allows you to provide custom error messages for when user input exceeds the max length for the address fields.
+You can provide custom error messages for each address field, and for both English and Welsh languages. If no custom error messages are provided, default error messages will be used.
+You must provide error messages for all address fields for a given language, you cannot mix and match default and custom error messages for a given language. For example, if you 
+provide a custom error message for `addressLine1` in English, you must also provide custom error messages for `addressLine2`, `addressLine3`, and `town` in English, but you can still 
+use the default error messages for Welsh. In addition, you must provide the full error message, including the field name, for example: "Address line 1 must be 35 characters or fewer". 
+This is because the default error messages will not be used to construct the custom error messages, so you must include the field name in the custom error message along with the max 
+length requirement.
+
+| Field name                | Description                                                                            | Optional/Required | Type    | Default value |
+|---------------------------|----------------------------------------------------------------------------------------|-------------------|---------|---------------|
+| `line1MaxLength`          | Max Length for Line 1 of the Address (must be between 35 and 255)                      | Optional          | Int     | 255           |
+| `line2MaxLength`          | Max Length for Line 2 of the Address (must be between 35 and 255)                      | Optional          | Int     | 255           |
+| `line3MaxLength`          | Max Length for Line 3 of the Address (must be between 35 and 255)                      | Optional          | Int     | 255           |
+| `townMaxLength`           | Max Length for Town/City of the Address (must be between 35 and 255)                   | Optional          | Int     | 255           |
+| `mandatoryFields`         | List of fields that are mandatory for the address to be valid                          | Optional          | Model   | None          |
+| `maxLengthErrorMessages`  | Custom error messages to display when user input exceeds max length for address fields | Optional          | Model   | None          |
+| `showOrganisationName`    | Whether or not to show the organisation name field on the manual address entry page    | Optional          | Boolean | True          |
 
 #### Mandatory Fields Configuration JSON object (Optional)
 

--- a/app/forms/ALFForms.scala
+++ b/app/forms/ALFForms.scala
@@ -18,9 +18,9 @@ package forms
 
 import controllers.Confirmed
 import forms.Helpers.EmptyStringValidator
-import model._
-import model.v2.{MandatoryFieldsConfigModel, ManualAddressEntryConfig}
-import play.api.data.Forms._
+import model.*
+import model.v2.{MandatoryFieldsConfigModel, ManualAddressEntryConfig, MaxLengthErrorMessage}
+import play.api.data.Forms.*
 import play.api.data.format.Formatter
 import play.api.data.validation.{Constraint, Invalid, Valid, ValidationError}
 import play.api.data.{FieldMapping, Form, FormError, Forms}
@@ -173,28 +173,58 @@ object ALFForms extends EmptyStringValidator {
         mandatoryConfig.town
       ).contains(true)
     }).contains(true)
-    
+
+    val localizedMaxLengthErrors: Option[MaxLengthErrorMessage] = {
+      val maxLengthErrors = optConfig.flatMap(_.maxLengthErrorMessages)
+      if (messages.lang.code == "cy") maxLengthErrors.flatMap(_.cy) else maxLengthErrors.flatMap(_.en)
+    }
+
+    def maxLengthMessage(select: MaxLengthErrorMessage => String, fallbackKey: String, max: Int): String =
+      localizedMaxLengthErrors
+        .map(select)
+        .getOrElse(messages(fallbackKey, max))
+
+    def nonEmptyOpt(value: String): Option[String] =
+      if (value == "") None else Some(value)
+
     Form(
       mapping(
         "organisation" -> optional(text),
-        "line1" -> atLeastOneAddressLineOrTown(messages(s"constants.editPageAtLeastOneLineOrTown"), mandatoryProvided)
-          .verifying(constraintOptStringMaxLength(messages(s"constants.editPageAddressLine1MaxErrorMessage", config.line1MaxLength + 1), config.line1MaxLength))
+        "line1" -> atLeastOneAddressLineOrTown(messages("constants.editPageAtLeastOneLineOrTown"), mandatoryProvided)
+          .verifying(
+            constraintOptStringMaxLength(
+              maxLengthMessage(_.addressLine1, "constants.editPageAddressLine1MaxErrorMessage", config.line1MaxLength),
+              config.line1MaxLength
+            )
+          )
           .verifying("editPage.line1.error", input => checkIfMandatory(input, _.addressLine1)),
         "line2" -> optional(text)
-          .verifying(constraintOptStringMaxLength(messages(s"constants.editPageAddressLine2MaxErrorMessage", config.line2MaxLength + 1), config.line2MaxLength))
+          .verifying(
+            constraintOptStringMaxLength(
+              maxLengthMessage(_.addressLine2, "constants.editPageAddressLine2MaxErrorMessage", config.line2MaxLength),
+              config.line2MaxLength
+            )
+          )
           .verifying("editPage.line2.error", input => checkIfMandatory(input, _.addressLine2)),
         "line3" -> optional(text)
-          .verifying(constraintOptStringMaxLength(messages(s"constants.editPageAddressLine3MaxErrorMessage", config.line3MaxLength + 1), config.line3MaxLength))
+          .verifying(
+            constraintOptStringMaxLength(
+              maxLengthMessage(_.addressLine3, "constants.editPageAddressLine3MaxErrorMessage", config.line3MaxLength),
+              config.line3MaxLength
+            )
+          )
           .verifying("editPage.line3.error", input => checkIfMandatory(input, _.addressLine3)),
         "town" -> optional(text)
-          .verifying(constraintOptStringMaxLength(messages(s"constants.editPageTownMaxErrorMessage", config.townMaxLength + 1), config.townMaxLength))
+          .verifying(
+            constraintOptStringMaxLength(
+              maxLengthMessage(_.town, "constants.editPageTownMaxErrorMessage", config.townMaxLength),
+              config.townMaxLength
+            )
+          )
           .verifying("editPage.town.error", input => checkIfMandatory(input, _.town)),
         "postcode" -> default(text, "").verifying(
-          if(isUkMode) "editPage.postcodeLabel.ukMode.error" else "editPage.postcode.error",
-          input => checkIfMandatory(
-            if(input == "") None else Some(input),
-            _.postcode
-          )
+          if (isUkMode) "editPage.postcodeLabel.ukMode.error" else "editPage.postcode.error",
+          input => checkIfMandatory(nonEmptyOpt(input), _.postcode)
         ),
         countryCodeMapping
       )(Edit.apply)(Edit.unapply)

--- a/app/model/v2/ManualAddressEntryConfig.scala
+++ b/app/model/v2/ManualAddressEntryConfig.scala
@@ -16,9 +16,9 @@
 
 package model.v2
 
-import play.api.libs.functional.syntax._
+import play.api.libs.functional.syntax.*
+import play.api.libs.json.*
 import play.api.libs.json.Reads.{max, min}
-import play.api.libs.json._
 
 case class ManualAddressEntryConfig(
                                      line1MaxLength: Int = ManualAddressEntryConfig.defaultMax,
@@ -26,6 +26,7 @@ case class ManualAddressEntryConfig(
                                      line3MaxLength: Int = ManualAddressEntryConfig.defaultMax,
                                      townMaxLength: Int = ManualAddressEntryConfig.defaultMax,
                                      mandatoryFields: Option[MandatoryFieldsConfigModel] = None,
+                                     maxLengthErrorMessages: Option[MaxLengthErrorMessages] = None,
                                      showOrganisationName: Boolean = true
                                    )
 
@@ -42,6 +43,7 @@ object ManualAddressEntryConfig {
       (__ \ "line3MaxLength").readWithDefault[Int](defaultMax)(constraints) and
       (__ \ "townMaxLength").readWithDefault[Int](defaultMax)(constraints) and
       (__ \ "mandatoryFields").readNullable[MandatoryFieldsConfigModel] and
+      (__ \ "maxLengthErrorMessages").readNullable[MaxLengthErrorMessages] and
       (__ \ "showOrganisationName").readWithDefault[Boolean](true)
   )(ManualAddressEntryConfig.apply _)
 

--- a/app/model/v2/MaxLengthErrorMessages.scala
+++ b/app/model/v2/MaxLengthErrorMessages.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model.v2
+
+import play.api.libs.json.{Json, OFormat, Writes}
+
+case class MaxLengthErrorMessages (
+    en: Option[MaxLengthErrorMessage] = None,
+    cy: Option[MaxLengthErrorMessage] = None
+)
+
+object MaxLengthErrorMessages {
+  implicit val format: OFormat[MaxLengthErrorMessages] = Json.format[MaxLengthErrorMessages]
+}
+
+case class MaxLengthErrorMessage (
+    addressLine1 : String,
+    addressLine2 : String,
+    addressLine3 : String,
+    town : String
+)
+
+object MaxLengthErrorMessage {
+  implicit val format: OFormat[MaxLengthErrorMessage] = Json.format[MaxLengthErrorMessage]
+}

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,10 @@ lazy val microservice = Project(appName, file("."))
       "uk.gov.hmrc.hmrcfrontend.views.config._",
       "controllers.routes._"
     ),
-    scalacOptions += "-Wconf:cat=unused-imports&src=html/.*:s",
-    scalacOptions += "-Wconf:cat=unused-imports&src=routes/.*:s"
+    // https://www.scala-lang.org/2021/01/12/configuring-and-suppressing-warnings.html
+    // suppress warnings in generated routes files
+    scalacOptions += "-Wconf:src=routes/.*:s",
+    scalacOptions += "-Wconf:msg=unused import&src=html/.*:s"
   )
   .settings(PlayKeys.playDefaultPort := 9028)
   .settings(CodeCoverageSettings.settings *)

--- a/conf/messages
+++ b/conf/messages
@@ -37,10 +37,10 @@ constants.forPostcode = for postcode
 constants.postcodeLabel.ukMode = UK postcode (optional)
 constants.postcodeLabel = Postcode (optional)
 
-constants.editPageAddressLine1MaxErrorMessage = The first address line needs to be fewer than {0} characters
-constants.editPageAddressLine2MaxErrorMessage = The second address line needs to be fewer than {0} characters
-constants.editPageAddressLine3MaxErrorMessage = The third address line needs to be fewer than {0} characters
-constants.editPageTownMaxErrorMessage = The town or city needs to be fewer than {0} characters
+constants.editPageAddressLine1MaxErrorMessage = Address line 1 needs to be {0} characters or less
+constants.editPageAddressLine2MaxErrorMessage = Address line 2 needs to be {0} characters or less
+constants.editPageAddressLine3MaxErrorMessage = Address line 3 needs to be {0} characters or less
+constants.editPageTownMaxErrorMessage = Town or city needs to be {0} characters or less
 constants.editPageAddressLine1MinErrorMessage = Enter the first line of address
 constants.editPageTownMinErrorMessage = Enter the town or city
 constants.editPagePostcodeErrorMessage.ukMode = Enter a valid UK postcode

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -37,10 +37,10 @@ constants.forPostcode = am y cod post
 constants.postcodeLabel.ukMode = Cod post yn y DU (dewisol)
 constants.postcodeLabel = Cod post (dewisol)
 
-constants.editPageAddressLine1MaxErrorMessage = Mae angen i linell gyntaf y cyfeiriad fod yn llai na {0} o gymeriadau
-constants.editPageAddressLine2MaxErrorMessage = Mae angen i ail linell y cyfeiriad fod yn llai na {0} o gymeriadau
-constants.editPageAddressLine3MaxErrorMessage = Mae angen i drydedd linell y cyfeiriad fod yn llai na {0} o gymeriadau
-constants.editPageTownMaxErrorMessage = Mae angen i’r dref neu’r ddinas fod yn llai na {0} o gymeriadau
+constants.editPageAddressLine1MaxErrorMessage = Address line 1 needs to be {0} characters or less
+constants.editPageAddressLine2MaxErrorMessage = Address line 2 needs to be {0} characters or less
+constants.editPageAddressLine3MaxErrorMessage = Address line 3 needs to be {0} characters or less
+constants.editPageTownMaxErrorMessage = Town or city needs to be {0} characters or less
 constants.editPageAddressLine1MinErrorMessage = Nodwch linell gyntaf y cyfeiriad
 constants.editPageTownMinErrorMessage = Nodwch y dref neu’r ddinas
 constants.editPagePostcodeErrorMessage.ukMode = Nodwch god post yn y DU sy’n ddilys

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -37,10 +37,10 @@ constants.forPostcode = am y cod post
 constants.postcodeLabel.ukMode = Cod post yn y DU (dewisol)
 constants.postcodeLabel = Cod post (dewisol)
 
-constants.editPageAddressLine1MaxErrorMessage = Address line 1 needs to be {0} characters or less
-constants.editPageAddressLine2MaxErrorMessage = Address line 2 needs to be {0} characters or less
-constants.editPageAddressLine3MaxErrorMessage = Address line 3 needs to be {0} characters or less
-constants.editPageTownMaxErrorMessage = Town or city needs to be {0} characters or less
+constants.editPageAddressLine1MaxErrorMessage = Mae angen i linell 1 y cyfeiriad fod yn {0} o gymeriadau neu lai
+constants.editPageAddressLine2MaxErrorMessage = Mae angen i linell 2 y cyfeiriad fod yn {0} o gymeriadau neu lai
+constants.editPageAddressLine3MaxErrorMessage = Mae angen i linell 3 y cyfeiriad fod yn {0} o gymeriadau neu lai
+constants.editPageTownMaxErrorMessage = Mae angen i''r dref neu’r ddinas fod yn {0} o gymeriadau neu lai
 constants.editPageAddressLine1MinErrorMessage = Nodwch linell gyntaf y cyfeiriad
 constants.editPageTownMinErrorMessage = Nodwch y dref neu’r ddinas
 constants.editPagePostcodeErrorMessage.ukMode = Nodwch god post yn y DU sy’n ddilys

--- a/test/forms/ALFFormsSpec.scala
+++ b/test/forms/ALFFormsSpec.scala
@@ -19,7 +19,7 @@ package forms
 import com.codahale.metrics.SharedMetricRegistries
 import forms.ALFForms.editForm
 import model.Edit
-import model.v2.{MandatoryFieldsConfigModel, ManualAddressEntryConfig}
+import model.v2.{MandatoryFieldsConfigModel, ManualAddressEntryConfig, MaxLengthErrorMessage, MaxLengthErrorMessages}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -157,10 +157,10 @@ class ALFFormsSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
           val boundForm = form.bind(data)
 
           boundForm.hasErrors.mustBe(true)
-          boundForm.errors.head.mustBe(FormError("line1", s"The first address line needs to be fewer than ${line1Limit + 1} characters", Seq(line1Limit)))
-          boundForm.errors(1).mustBe(FormError("line2", s"The second address line needs to be fewer than ${line2Limit + 1} characters", Seq(line2Limit)))
-          boundForm.errors(2).mustBe(FormError("line3", s"The third address line needs to be fewer than ${line3Limit + 1} characters", Seq(line3Limit)))
-          boundForm.errors(3).mustBe(FormError("town", s"The town or city needs to be fewer than ${townLimit + 1} characters", Seq(townLimit)))
+          boundForm.errors.head.mustBe(FormError("line1", s"Address line 1 needs to be $line1Limit characters or less", Seq(line1Limit)))
+          boundForm.errors(1).mustBe(FormError("line2", s"Address line 2 needs to be $line2Limit characters or less", Seq(line2Limit)))
+          boundForm.errors(2).mustBe(FormError("line3", s"Address line 3 needs to be $line3Limit characters or less", Seq(line3Limit)))
+          boundForm.errors(3).mustBe(FormError("town", s"Town or city needs to be $townLimit characters or less", Seq(townLimit)))
         }
       }
 
@@ -239,10 +239,10 @@ class ALFFormsSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
           val boundForm = form.bind(data)
 
           boundForm.hasErrors.mustBe(true)
-          boundForm.errors.head.mustBe(FormError("line1", s"The first address line needs to be fewer than ${line1Limit + 1} characters", Seq(line1Limit)))
-          boundForm.errors(1).mustBe(FormError("line2", s"The second address line needs to be fewer than ${line2Limit + 1} characters", Seq(line2Limit)))
-          boundForm.errors(2).mustBe(FormError("line3", s"The third address line needs to be fewer than ${line3Limit + 1} characters", Seq(line3Limit)))
-          boundForm.errors(3).mustBe(FormError("town", s"The town or city needs to be fewer than ${townLimit + 1} characters", Seq(townLimit)))
+          boundForm.errors.head.mustBe(FormError("line1", s"Address line 1 needs to be $line1Limit characters or less", Seq(line1Limit)))
+          boundForm.errors(1).mustBe(FormError("line2", s"Address line 2 needs to be $line2Limit characters or less", Seq(line2Limit)))
+          boundForm.errors(2).mustBe(FormError("line3", s"Address line 3 needs to be $line3Limit characters or less", Seq(line3Limit)))
+          boundForm.errors(3).mustBe(FormError("town", s"Town or city needs to be $townLimit characters or less", Seq(townLimit)))
         }
       }
 
@@ -275,11 +275,11 @@ class ALFFormsSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
       }
     }
   }
-  
+
   "editForm" should {
-    
+
     "return no errors with valid data" when {
-      
+
       "when none of the fields are mandatory and line 1 is given" in {
         val data = Map(
           "line1" -> "foo1"
@@ -299,42 +299,42 @@ class ALFFormsSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
 
         form.bind(data).hasErrors mustBe false
       }
-      
+
       "line 2 is set to mandatory and line 1 and town are not provided" in {
         val data = Map(
           "line2" -> "Some Line"
         )
-        
+
         val form = editForm(Some(ManualAddressEntryConfig(
           mandatoryFields = Some(MandatoryFieldsConfigModel(
             addressLine2 = true
           ))
         )), isUkMode = true)
-        
+
         form.bind(data).hasErrors mustBe false
-        
+
       }
-      
+
     }
-    
+
     "return a single error for the mandatory line when one is set to mandatory and no data is provided" in {
       val data: Map[String, String] = Map()
-      
+
       val form = editForm(Some(ManualAddressEntryConfig(
         mandatoryFields = Some(MandatoryFieldsConfigModel(
           addressLine3 = true
         ))
       )), isUkMode = true)
       val boundForm = form.bind(data)
-      
+
       boundForm.hasErrors mustBe true
       boundForm.errors.length mustBe 1
       boundForm.errors.head.key mustBe "line3"
     }
-    
+
     "return an error for each missing line when they are set to mandatory" which {
       case class Data(testingLine: String, data: Map[String, String], modelMap: MandatoryFieldsConfigModel => MandatoryFieldsConfigModel)
-      
+
       val testData = Seq(
         Data("line1", Map("town" -> "Some Town"), _.copy(addressLine1 = true)),
         Data("line2", Map("line1" -> "line1"), _.copy(addressLine2 = true)),
@@ -342,11 +342,11 @@ class ALFFormsSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
         Data("postcode", Map("line1" -> "line1"), _.copy(postcode = true)),
         Data("town", Map("line1" -> "line1"), _.copy(town = true))
       )
-      
+
       val allFalseModel = MandatoryFieldsConfigModel(
         addressLine1 = false, addressLine2 = false, addressLine3 = false, postcode = false, town = false
       )
-      
+
       testData.foreach { data =>
         s"testing ${data.testingLine} errors if missing when set to mandatory" in {
           val settingsModel = Some(ManualAddressEntryConfig(
@@ -354,10 +354,74 @@ class ALFFormsSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
           ))
           val form = editForm(settingsModel, isUkMode = true)
           val result = form.bind(data.data)
-          
+
           result.hasErrors mustBe true
           result.errors.length mustBe 1
         }
+      }
+    }
+
+    "return custom error messages for max length fields" when {
+      val line1Limit = 50
+      val line2Limit = 60
+      val line3Limit = 70
+      val townLimit = 80
+
+      val config: ManualAddressEntryConfig = ManualAddressEntryConfig(
+        line1MaxLength = line1Limit,
+        line2MaxLength = line2Limit,
+        line3MaxLength = line3Limit,
+        townMaxLength = townLimit,
+        mandatoryFields = None,
+        maxLengthErrorMessages = Some(MaxLengthErrorMessages(
+          en = Some(MaxLengthErrorMessage(
+            addressLine1 = "line 1 custom max length error",
+            addressLine2 = "line 2 custom max length error",
+            addressLine3 = "line 3 custom max length error",
+            town = "town custom max length error"
+          )),
+          cy = Some(MaxLengthErrorMessage(
+            addressLine1 = "line 1 custom max length error welsh",
+            addressLine2 = "line 2 custom max length error welsh",
+            addressLine3 = "line 3 custom max length error welsh",
+            town = "town custom max length error welsh"
+          ))
+        ))
+      )
+
+      val data: Map[String, String] = Map(
+        "line1" -> ("A" * line1Limit + 1),
+        "line2" -> ("A" * line2Limit + 1),
+        "line3" -> ("A" * line3Limit + 1),
+        "town" -> ("A" * townLimit + 1),
+        "postcode" -> "ZZ11ZZ",
+        "countryCode" -> "GB"
+      )
+
+      "in English" in {
+        implicit val messages: Messages = messagesApi.preferred(Seq(Lang("en")))
+
+        val form: Form[Edit] = ALFForms.editForm(Some(config), isUkMode = true)
+        val boundForm = form.bind(data)
+
+        boundForm.hasErrors.mustBe(true)
+        boundForm.errors.head.mustBe(FormError("line1", s"line 1 custom max length error", Seq(line1Limit)))
+        boundForm.errors(1).mustBe(FormError("line2", s"line 2 custom max length error", Seq(line2Limit)))
+        boundForm.errors(2).mustBe(FormError("line3", s"line 3 custom max length error", Seq(line3Limit)))
+        boundForm.errors(3).mustBe(FormError("town", s"town custom max length error", Seq(townLimit)))
+      }
+
+      "in Welsh" in {
+        implicit val messages: Messages = messagesApi.preferred(Seq(Lang("cy")))
+
+        val form: Form[Edit] = ALFForms.editForm(Some(config), isUkMode = true)
+        val boundForm = form.bind(data)
+
+        boundForm.hasErrors.mustBe(true)
+        boundForm.errors.head.mustBe(FormError("line1", s"line 1 custom max length error welsh", Seq(line1Limit)))
+        boundForm.errors(1).mustBe(FormError("line2", s"line 2 custom max length error welsh", Seq(line2Limit)))
+        boundForm.errors(2).mustBe(FormError("line3", s"line 3 custom max length error welsh", Seq(line3Limit)))
+        boundForm.errors(3).mustBe(FormError("town", s"town custom max length error welsh", Seq(townLimit)))
       }
     }
   }


### PR DESCRIPTION
This pull request introduces support for custom max length error messages for address fields in both English and Welsh, allowing services to override the default validation messages for manual address entry. It updates the configuration model, form logic, documentation, and tests to support this new feature.

**Custom error messages for address field max lengths:**

* Added a new `maxLengthErrorMessages` property to the `ManualAddressEntryConfig` model, allowing configuration of custom error messages for address line 1, 2, 3, and town fields, in both English and Welsh (`app/model/v2/ManualAddressEntryConfig.scala`, `app/model/v2/MaxLengthErrorMessages.scala`). [[1]](diffhunk://#diff-cd850b38b06a1a3a98eb304a0dcb1f06e8c4d7b5c245fe197f94e48a9ca6e039L19-R29) [[2]](diffhunk://#diff-cd850b38b06a1a3a98eb304a0dcb1f06e8c4d7b5c245fe197f94e48a9ca6e039R46) [[3]](diffhunk://#diff-e6cc54231654674c7208416c8e4915db6028ae70cf65a100844c8274b552b12dR1-R39)
* Updated the form logic in `ALFForms` to use these custom messages if provided, falling back to the default messages otherwise (`app/forms/ALFForms.scala`).

**Documentation updates:**

* Expanded the `README.md` to document how to use the new `maxLengthErrorMessages` configuration, including requirements and usage examples (`README.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R118-R131) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R324-R339)

**Default error message improvements:**

* Updated the default max length error messages in both English and Welsh message files for clarity and consistency (`conf/messages`, `conf/messages.cy`). [[1]](diffhunk://#diff-d72bee814e0a829fc92c6a7338c2ad45420343749e1764cb94c19a7e37d9b06cL40-R43) [[2]](diffhunk://#diff-53dbf1f5e6e7c42ddc61eec700fa0ed89ad80537a1ff14e6d59ef20a03eef2f4L40-R43)

**Testing enhancements:**

* Added and updated tests to verify that custom max length error messages are correctly used in both English and Welsh, and that the default messages are used when custom messages are not provided (`test/forms/ALFFormsSpec.scala`). [[1]](diffhunk://#diff-ca6a390c068cc23d954f4403e2bf73e13825d803e3887f627a288a9f2ec5819fL22-R22) [[2]](diffhunk://#diff-ca6a390c068cc23d954f4403e2bf73e13825d803e3887f627a288a9f2ec5819fL149-R162) [[3]](diffhunk://#diff-ca6a390c068cc23d954f4403e2bf73e13825d803e3887f627a288a9f2ec5819fL232-R244) [[4]](diffhunk://#diff-ca6a390c068cc23d954f4403e2bf73e13825d803e3887f627a288a9f2ec5819fR362-R425)

These changes make it easier for services to provide tailored validation feedback to users in both supported languages.

This PR requires acceptance tests changes https://github.com/hmrc/address-lookup-frontend-ui-tests/pull/10