### PR TITLE
CIR-2925 Update to provide example of international address label overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,17 @@ If your service doesn't have Welsh translations you can disable them setting the
         "postcodeLabel": "Postcode (optional)",
         "countryLabel": "Country",
         "submitLabel": "Continue"
+      },
+      "international": {
+        "editPageLabels": {
+          "organisationLabel": "Organisation international",
+          "line1Label": "Line 1 international",
+          "line2Label": "Line 2 international",
+          "line3Label": "Line 3 international",
+          "townLabel": "City international",
+          "postcodeLabel": "postcode international",
+          "countryLabel": "Country international"
+        }
       }
     },
     "cy": {
@@ -231,6 +242,17 @@ If your service doesn't have Welsh translations you can disable them setting the
         "postcodeLabel": "Postcode (optional) welsh",
         "countryLabel": "Country welsh",
         "submitLabel": "Continue welsh"
+      },
+      "international": {
+        "editPageLabels": {
+          "organisationLabel": "Organisation international welsh",
+          "line1Label": "Line 1 international welsh",
+          "line2Label": "Line 2 international welsh",
+          "line3Label": "Line 3 international welsh",
+          "townLabel": "City international welsh",
+          "postcodeLabel": "postcode international welsh",
+          "countryLabel": "Country international welsh"
+        }
       }
     }
   }
@@ -410,6 +432,40 @@ You can restrict the list if required by specifying only the desired country cod
     "DE",
     "IT"
 ],
+
+#### International Manually Entered Addresses labels overrides (Optional)
+You can provide custom labels for the international address fields by adding an `international` block to the `labels` section of the config. If no custom content is provided, the default labels are used.
+
+Example JSON for international labels overrides:
+```json
+{
+  "version": 2,
+  "options": {
+    "continueUrl": "This will be ignored",
+    "useNewGovUkServiceNavigation": false,
+    "ukMode": false
+  },
+  "labels": {
+    "en": {
+      "international": {
+        "editPageLabels": {
+          "title": "Enter address international",
+          "heading": "Enter address international",
+          "organisationLabel": "Organisation international",
+          "line1Label": "Line 1 international",
+          "line2Label": "Line 2 international",
+          "line3Label": "Line 3 international",
+          "townLabel": "City international",
+          "postcodeLabel": "postcode international",
+          "countryLabel": "Country international",
+          "submitLabel": "Continue international"
+        }
+      }
+    }
+  }
+}
+```
+
 
 ### Obtaining the Confirmed Address
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,8 +3,8 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapPlayVersion = "10.5.0"
-  private val hmrcFrontendPlayVersion = "12.27.0"
+  private val bootstrapPlayVersion = "10.7.0"
+  private val hmrcFrontendPlayVersion = "12.32.0"
   private val hmrcMongoPlayVersion = "2.12.0"
   private val jacksonVersion = "3.0.3"
 
@@ -13,7 +13,7 @@ object AppDependencies {
     "uk.gov.hmrc"             %% "bootstrap-frontend-play-30"             % bootstrapPlayVersion,
     "uk.gov.hmrc"             %% "play-frontend-hmrc-play-30"             % hmrcFrontendPlayVersion,
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-30"                     % hmrcMongoPlayVersion,
-    "uk.gov.hmrc"             %% "play-conditional-form-mapping-play-30"  % "3.4.0",
+    "uk.gov.hmrc"             %% "play-conditional-form-mapping-play-30"  % "3.5.0",
     "com.github.tototoshi"    %% "scala-csv"                              % "2.0.0",
     "net.ruippeixotog"        %% "scala-scraper"                          % "3.2.0",
     "uk.gov.hmrc.objectstore" %% "object-store-client-play-30"            % "2.5.0"


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to support custom label overrides for international addresses in both English and Welsh. It explains how to configure these overrides and provides example JSON for easy integration.

**International address label overrides:**

**Documentation improvements:**

* Added a new section describing how to provide custom international address labels, including a sample JSON configuration for easy reference.[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R180-R190) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R245-R255)