### PR TITLE
CIR-2958 Re-introduce outbound proxy

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -46,7 +46,7 @@ class Module(environment: Environment, playConfig: Configuration) extends Abstra
       new WelshCountryNamesDataSource(english)  
     } else {
       logger.info(s"Using gov-wales country data from object-store")
-      new WelshCountryNamesObjectStoreDataSource(english, objectStore, ec, mat)
+      new WelshCountryNamesObjectStoreDataSource(english, objectStore, playConfig, ec, mat)
     }
   }
 }

--- a/app/services/WelshCountryNamesDataSource.scala
+++ b/app/services/WelshCountryNamesDataSource.scala
@@ -20,7 +20,7 @@ import address.v2.Country
 import com.github.tototoshi.csv.{CSVFormat, CSVReader, DefaultCSVFormat}
 import org.apache.pekko.stream.Materializer
 import org.jsoup.Jsoup
-import play.api.Logging
+import play.api.{Configuration, Logging}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.objectstore.client.Path
 import uk.gov.hmrc.objectstore.client.play.Implicits.*
@@ -107,16 +107,38 @@ class WelshCountryNamesDataSource @Inject() (english: EnglishCountryNamesDataSou
 class WelshCountryNamesObjectStoreDataSource  @Inject() (
                                                           englishCountryNamesDataSource: EnglishCountryNamesDataSource,
                                                           objectStore: PlayObjectStoreClient,
+                                                          config: Configuration,
                                                           implicit val ec: ExecutionContext,
                                                           implicit val materializer: Materializer) extends WelshCountryNamesDataSource(englishCountryNamesDataSource) with Logging {
 
   private val objectStorePath = Path.Directory("govwales").file("country-names.csv")
 
-  protected[services] def resolveGovWalesDownloadUrl(): String =
-    Jsoup.connect("https://www.gov.wales/bydtermcymru/international-place-names")
+
+  protected[services] def outboundProxy: Option[(String, Int)] = {
+    val maybeHost = config.getOptional[String]("proxy.host").map(_.trim).filter(_.nonEmpty)
+    val maybePort = config.getOptional[Int]("proxy.port")
+
+    (maybeHost, maybePort) match {
+      case (Some(host), Some(port)) => Some((host, port))
+      case (Some(_), None) =>
+        logger.warn("[outboundProxy] - Gov Wales proxy host is set but port is missing; proceeding without proxy")
+        None
+      case (None, Some(_)) =>
+        logger.warn("[outboundProxy] - Gov Wales proxy port is set but host is missing; proceeding without proxy")
+        None
+      case _ => None
+    }
+  }
+
+  protected[services] def resolveGovWalesDownloadUrl(): String = {
+    val connection = Jsoup.connect("https://www.gov.wales/bydtermcymru/international-place-names")
+    outboundProxy.foreach { case (host, port) => connection.proxy(host, port) }
+
+    connection
       .get()
       .select("a:containsOwn(Enwau gwledydd)")
       .attr("abs:href")
+  }
 
   protected[services] def downloadContent(url: String): String =
     Using.resource(URI.create(url).toURL.openStream()) { in =>

--- a/test/services/WelshCountryNamesObjectStoreDataSourceSpec.scala
+++ b/test/services/WelshCountryNamesObjectStoreDataSourceSpec.scala
@@ -17,14 +17,15 @@
 package services
 
 import org.apache.pekko.stream.Materializer
-import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq as eqTo}
 import org.mockito.Mockito.{verify, verifyNoInteractions, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import uk.gov.hmrc.objectstore.client.{ObjectSummaryWithMd5, Path}
+import play.api.Configuration
 import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
+import uk.gov.hmrc.objectstore.client.{ObjectSummaryWithMd5, Path}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -47,7 +48,8 @@ class WelshCountryNamesObjectStoreDataSourceSpec
   class Scenario(
     resolveDownloadUrl: () => String = () => "https://example.com/country-names.csv",
     downloadContentFromUrl: String => String = _ => validGovWalesCsv,
-    putObjectResult: Future[ObjectSummaryWithMd5] = Future.successful(null.asInstanceOf[ObjectSummaryWithMd5])
+    putObjectResult: Future[ObjectSummaryWithMd5] = Future.successful(null.asInstanceOf[ObjectSummaryWithMd5]),
+    config: Configuration = app.configuration
   ) {
     implicit val ec: ExecutionContext = ExecutionContext.global
     implicit val materializer: Materializer = app.materializer
@@ -59,7 +61,7 @@ class WelshCountryNamesObjectStoreDataSourceSpec
     when(objectStore.putObject(any[Path.File], any[String], any(), any(), any(), any())(any(), any()))
       .thenReturn(putObjectResult)
 
-    val service: WelshCountryNamesObjectStoreDataSource = new WelshCountryNamesObjectStoreDataSource(english, objectStore, ec, materializer) {
+    val service: WelshCountryNamesObjectStoreDataSource = new WelshCountryNamesObjectStoreDataSource(english, objectStore, config, ec, materializer) {
       override protected[services] def resolveGovWalesDownloadUrl(): String = resolveDownloadUrl()
       override protected[services] def downloadContent(url: String): String = downloadContentFromUrl(url)
     }
@@ -101,6 +103,38 @@ class WelshCountryNamesObjectStoreDataSourceSpec
 
       service.countriesCY.find(_.code == "AF").get.name mustBe originalAfghanistanName
       verifyNoInteractions(objectStore)
+    }
+  }
+
+  "outboundProxy" should {
+    "return configured proxy when host and port are present" in new Scenario(
+      config = Configuration.from(Map("proxy.host" -> "proxy.local", "proxy.port" -> 8080))
+    ) {
+      service.outboundProxy mustBe Some("proxy.local" -> 8080)
+    }
+
+    "trim host value before returning proxy" in new Scenario(
+      config = Configuration.from(Map("proxy.host" -> "  proxy.local  ", "proxy.port" -> 8080))
+    ) {
+      service.outboundProxy mustBe Some("proxy.local" -> 8080)
+    }
+
+    "return no proxy when host is configured without port" in new Scenario(
+      config = Configuration.from(Map("proxy.host" -> "proxy.local"))
+    ) {
+      service.outboundProxy mustBe None
+    }
+
+    "return no proxy when port is configured without host" in new Scenario(
+      config = Configuration.from(Map("proxy.port" -> 8080))
+    ) {
+      service.outboundProxy mustBe None
+    }
+
+    "return no proxy when host is blank" in new Scenario(
+      config = Configuration.from(Map("proxy.host" -> "   ", "proxy.port" -> 8080))
+    ) {
+      service.outboundProxy mustBe None
     }
   }
 }


### PR DESCRIPTION
This pull request introduces support for using an outbound proxy when downloading Welsh country names from the Gov Wales website. The main changes involve updating the `WelshCountryNamesObjectStoreDataSource` to read proxy settings from configuration, use them when connecting to the external site, and adding tests to verify this behavior.

**Support for outbound proxy configuration:**

* `WelshCountryNamesObjectStoreDataSource` now accepts a `Configuration` parameter and reads `proxy.host` and `proxy.port` settings to optionally use a proxy when connecting to the Gov Wales site. The proxy host is trimmed, and appropriate warnings are logged if only one of host or port is set. (`app/services/WelshCountryNamesDataSource.scala` [app/services/WelshCountryNamesDataSource.scalaR110-R141](diffhunk://#diff-8e816d36fe4b586bd29f029ac273d9765d3cfd2964da54a25430b78f0b737fe9R110-R141))
* The `resolveGovWalesDownloadUrl` method uses the configured proxy (if present) when connecting to the external site. (`app/services/WelshCountryNamesDataSource.scala` [app/services/WelshCountryNamesDataSource.scalaR110-R141](diffhunk://#diff-8e816d36fe4b586bd29f029ac273d9765d3cfd2964da54a25430b78f0b737fe9R110-R141))

**Dependency injection and wiring changes:**

* The `WelshCountryNamesObjectStoreDataSource` constructor and its usage in the application wiring (`Module.scala`) were updated to pass the `Configuration` instance. (`app/Module.scala` [[1]](diffhunk://#diff-dee83a1cc185d339e3719c8cf9b4718f85731f2202e1dda94e688d65104a753dL49-R49) `app/services/WelshCountryNamesDataSource.scala` [[2]](diffhunk://#diff-8e816d36fe4b586bd29f029ac273d9765d3cfd2964da54a25430b78f0b737fe9L23-R23)

**Testing improvements:**

* The test suite for `WelshCountryNamesObjectStoreDataSource` was updated to support injecting custom configuration and now includes comprehensive tests for the new proxy logic, verifying behavior for all combinations of host and port settings. (`test/services/WelshCountryNamesObjectStoreDataSourceSpec.scala` [[1]](diffhunk://#diff-79c9bb922c118d955a96f296d365dc281d6a6a364bd2186329401f86f5e93f6dL50-R52) [[2]](diffhunk://#diff-79c9bb922c118d955a96f296d365dc281d6a6a364bd2186329401f86f5e93f6dL62-R64) [[3]](diffhunk://#diff-79c9bb922c118d955a96f296d365dc281d6a6a364bd2186329401f86f5e93f6dR108-R139)

**Code style and imports:**

* Minor code style updates, including import changes for Play's `Configuration` and Scala 3 syntax for `eq as eqTo`. (`app/services/WelshCountryNamesDataSource.scala` [[1]](diffhunk://#diff-8e816d36fe4b586bd29f029ac273d9765d3cfd2964da54a25430b78f0b737fe9L23-R23) `test/services/WelshCountryNamesObjectStoreDataSourceSpec.scala` [[2]](diffhunk://#diff-79c9bb922c118d955a96f296d365dc281d6a6a364bd2186329401f86f5e93f6dL20-R28)

These changes ensure that the service can be configured to use a proxy for outbound HTTP requests, improving compatibility with restricted network environments.