### PR TITLE
Cir 2958

### DIFF
--- a/app/services/WelshCountryNamesDataSource.scala
+++ b/app/services/WelshCountryNamesDataSource.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.objectstore.client.play.Implicits.*
 import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
 
 import java.io.InputStream
-import java.net.URI
+import java.net.{InetSocketAddress, Proxy, URI}
 import java.nio.charset.StandardCharsets
 import javax.inject.{Inject, Singleton}
 import scala.collection.immutable.SortedMap
@@ -114,23 +114,29 @@ class WelshCountryNamesObjectStoreDataSource  @Inject() (
   private val objectStorePath = Path.Directory("govwales").file("country-names.csv")
 
 
-  protected[services] def outboundProxy: Option[(String, Int)] = {
+  val outboundProxy: Option[(String, Int)] = {
     val maybeHost = config.getOptional[String]("proxy.host").map(_.trim).filter(_.nonEmpty)
     val maybePort = config.getOptional[Int]("proxy.port")
 
     (maybeHost, maybePort) match {
-      case (Some(host), Some(port)) => Some((host, port))
+      case (Some(host), Some(port)) =>
+        logger.info("[outboundProxy] - Gov Wales proxy defined")
+        Some((host, port))
       case (Some(_), None) =>
         logger.warn("[outboundProxy] - Gov Wales proxy host is set but port is missing; proceeding without proxy")
         None
       case (None, Some(_)) =>
         logger.warn("[outboundProxy] - Gov Wales proxy port is set but host is missing; proceeding without proxy")
         None
-      case _ => None
+      case _ =>
+        logger.warn("[outboundProxy] - Gov Wales proxy is not defined")
+        None
     }
   }
 
   protected[services] def resolveGovWalesDownloadUrl(): String = {
+    logger.info("[resolveGovWalesDownloadUrl] - Resolving Welsh Government country names download URL")
+
     val connection = Jsoup.connect("https://www.gov.wales/bydtermcymru/international-place-names")
     outboundProxy.foreach { case (host, port) => connection.proxy(host, port) }
 
@@ -140,10 +146,23 @@ class WelshCountryNamesObjectStoreDataSource  @Inject() (
       .attr("abs:href")
   }
 
-  protected[services] def downloadContent(url: String): String =
-    Using.resource(URI.create(url).toURL.openStream()) { in =>
+  protected[services] def downloadContent(url: String): String = {
+    logger.info(s"[downloadContent] - Downloading Welsh Government country names data from URL: $url")
+
+    Using.resource {
+      val targetUrl = URI.create(url).toURL
+      val connection = outboundProxy
+        .map { case (host, port) =>
+          val proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(host, port))
+          targetUrl.openConnection(proxy)
+        }
+        .getOrElse(targetUrl.openConnection())
+
+      connection.getInputStream
+    } { in =>
       new String(in.readAllBytes(), StandardCharsets.UTF_8)
     }
+  }
 
   override def retrieveAndStoreData(): Future[Unit] = {
     try {


### PR DESCRIPTION
This pull request enhances the `WelshCountryNamesObjectStoreDataSource` service with improved proxy support and more robust logging to aid in debugging and monitoring. The changes ensure that outbound connections respect proxy settings and provide better visibility into the service's behavior when resolving URLs and downloading content.

**Proxy support and logging improvements:**

* Added imports for `InetSocketAddress` and `Proxy` to enable explicit proxy configuration for outbound HTTP connections.
* Updated the `outboundProxy` method to log whether a proxy is defined, partially defined, or missing, improving traceability of proxy configuration issues.
* Added logging to `resolveGovWalesDownloadUrl` to indicate when the download URL is being resolved.
* Modified `downloadContent` to:
  - Log the URL being downloaded for better traceability.
  - Use proxy settings (if defined) when opening connections, ensuring all outbound HTTP requests respect proxy configuration.
  - Refactor the resource handling to use the potentially proxied connection.